### PR TITLE
Add current account and a few other minor tweaks

### DIFF
--- a/cmd/internal/profile/current_command.go
+++ b/cmd/internal/profile/current_command.go
@@ -12,6 +12,10 @@ func currentCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "current",
 		Usage: "Outputs the account you currently have selected",
+
+		// Use a space to cause the args usage to not be displayed since the `current` command
+		// doesn't accept any arguments
+		ArgsUsage: " ",
 		Action: func(ctx *cli.Context) error {
 			if _, err := os.Lstat(currentPath); err != nil {
 				return fmt.Errorf("no account is currently selected: %w", err)

--- a/cmd/internal/profile/current_command.go
+++ b/cmd/internal/profile/current_command.go
@@ -1,0 +1,31 @@
+package profile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+)
+
+func currentCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "current",
+		Usage: "Outputs the account you currently have selected",
+		Action: func(ctx *cli.Context) error {
+			if _, err := os.Lstat(currentPath); err != nil {
+				return fmt.Errorf("no account is currently selected: %w", err)
+			}
+
+			linkTarget, err := os.Readlink(currentPath)
+			if err != nil {
+				return fmt.Errorf("could not find the target of the current account symlink: %w", err)
+			}
+
+			alias := filepath.Base(linkTarget)
+			fmt.Println(alias)
+
+			return nil
+		},
+	}
+}

--- a/cmd/internal/profile/current_command.go
+++ b/cmd/internal/profile/current_command.go
@@ -11,7 +11,7 @@ import (
 func currentCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "current",
-		Usage: "Outputs the account you currently have selected",
+		Usage: "Outputs your currently selected profile",
 
 		// Use a space to cause the args usage to not be displayed since the `current` command
 		// doesn't accept any arguments

--- a/cmd/internal/profile/login_command.go
+++ b/cmd/internal/profile/login_command.go
@@ -98,6 +98,8 @@ func loginUsingAPIKey(reader *bufio.Reader, creds *session.StoredCredentials) er
 	}
 	creds.KeySecret = strings.TrimSpace(string(keySecret))
 
+	fmt.Println()
+
 	return nil
 }
 
@@ -109,6 +111,8 @@ func loginUsingGitHubAccessToken(creds *session.StoredCredentials) error {
 		return err
 	}
 	creds.AccessToken = strings.TrimSpace(string(accessToken))
+
+	fmt.Println()
 
 	return nil
 }

--- a/cmd/internal/profile/login_command.go
+++ b/cmd/internal/profile/login_command.go
@@ -17,10 +17,11 @@ import (
 
 func loginCommand() *cli.Command {
 	return &cli.Command{
-		Name:   "login",
-		Usage:  "Create a profile for a Spacelift account",
-		Before: getAlias,
-		Action: loginAction,
+		Name:      "login",
+		Usage:     "Create a profile for a Spacelift account",
+		Before:    getAlias,
+		ArgsUsage: "<account-alias>",
+		Action:    loginAction,
 	}
 }
 

--- a/cmd/internal/profile/logout_command.go
+++ b/cmd/internal/profile/logout_command.go
@@ -9,9 +9,10 @@ import (
 
 func logoutCommand() *cli.Command {
 	return &cli.Command{
-		Name:   "logout",
-		Usage:  "Remove Spacelift credentials for an existing profile",
-		Before: getAlias,
+		Name:      "logout",
+		Usage:     "Remove Spacelift credentials for an existing profile",
+		ArgsUsage: "<account-alias>",
+		Before:    getAlias,
 		Action: func(*cli.Context) error {
 			if _, err := os.Stat(aliasPath); err != nil {
 				return fmt.Errorf("you don't seem to be have any Spacelift credentials associated with %s: %v", profileAlias, err)

--- a/cmd/internal/profile/profile.go
+++ b/cmd/internal/profile/profile.go
@@ -36,6 +36,7 @@ func Command() *cli.Command {
 			return nil
 		},
 		Subcommands: []*cli.Command{
+			currentCommand(),
 			loginCommand(),
 			logoutCommand(),
 			selectCommand(),

--- a/cmd/internal/profile/select_command.go
+++ b/cmd/internal/profile/select_command.go
@@ -9,9 +9,10 @@ import (
 
 func selectCommand() *cli.Command {
 	return &cli.Command{
-		Name:   "select",
-		Usage:  "Select one of existing Spacelift profile",
-		Before: getAlias,
+		Name:      "select",
+		Usage:     "Select one of existing Spacelift accounts",
+		ArgsUsage: "<account-alias>",
+		Before:    getAlias,
 		Action: func(*cli.Context) error {
 			if _, err := os.Stat(aliasPath); err != nil {
 				return fmt.Errorf("could not select profile %s: %w", profileAlias, err)

--- a/cmd/internal/profile/select_command.go
+++ b/cmd/internal/profile/select_command.go
@@ -10,7 +10,7 @@ import (
 func selectCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "select",
-		Usage:     "Select one of existing Spacelift accounts",
+		Usage:     "Select one of your Spacelift account profiles",
 		ArgsUsage: "<account-alias>",
 		Before:    getAlias,
 		Action: func(*cli.Context) error {


### PR DESCRIPTION
## `account current` command

Added a new command to output the current selected account:

```shell
$ go run spacelift-cli.go -- account current
adamconnelly-admin
```

Here's the usage:

```shell
$ go run spacelift-cli.go -- account current --help
NAME:
   spacelift-cli account current - Outputs the account you currently have selected

USAGE:
   spacelift-cli account current [command options]

OPTIONS:
   --help, -h  show help (default: false)
```

## Adding missing newlines

I noticed while logging in my shell was displaying a `%` after the commands completed. For example:

```shell
$ go run spacelift-cli.go -- account login adamconnelly-admin
Enter Spacelift endpoint (eg. https://unicorn.app.spacelift.io/): https://adamconnelly.app.spacelift.io/
Select credentials type: 1 for API key, 2 for GitHub access token: 1
Enter API key ID: ***
Enter API key secret: %
$
```

It now looks like this:

```shell
$ go run spacelift-cli.go -- account login adamconnelly-admin
Enter Spacelift endpoint (eg. https://unicorn.app.spacelift.io/): https://adamconnelly.app.spacelift.io
Select credentials type: 1 for API key, 2 for GitHub access token: 1
Enter API key ID: ***
Enter API key secret:
$
```

## ArgsUsage

I've updated the account commands that accept an alias so that's reflected in the usage. Before it just displayed a generic `[arguments...]` text:

```text
USAGE:
   spacelift-cli account logout [command options] [arguments...]
```

Now it looks like this:

```shell
USAGE:
   spacelift-cli account logout [command options] <account-alias>
```