### PR TITLE
Simplify binary names inside archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ BINARY := spacectl
 PKG := github.com/spacelift-io/spacectl
 BUILD_FLAGS := -a -tags netgo -ldflags '-w -extldflags "-static"'
 
+# Transforms from the architecture-specific binary name to a simple binary name inside the archive
+TAR_TRANSFORM := --transform='flags=r;s|$(BINARY).*|spacectl|'
+WIN_TAR_TRANSFORM := --transform='flags=r;s|$(BINARY).*|spacectl.exe|'
+
 darwin:
 	env GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-darwin-amd64 $(PKG)
 	env GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-darwin-arm64 $(PKG)
@@ -16,11 +20,11 @@ windows:
 build: darwin linux windows
 
 release: build
-	cd build; tar -czf $(BINARY)-darwin-amd64.tar.gz $(BINARY)-darwin-amd64
-	cd build; tar -czf $(BINARY)-darwin-arm64.tar.gz $(BINARY)-darwin-arm64
-	cd build; tar -czf $(BINARY)-linux-amd64.tar.gz $(BINARY)-linux-amd64
-	cd build; tar -czf $(BINARY)-linux-arm64.tar.gz $(BINARY)-linux-arm64
-	cd build; tar -czf $(BINARY)-windows-amd64.tar.gz $(BINARY)-windows-amd64
+	cd build; tar -czf $(BINARY)-darwin-amd64.tar.gz $(TAR_TRANSFORM) $(BINARY)-darwin-amd64
+	cd build; tar -czf $(BINARY)-darwin-arm64.tar.gz $(TAR_TRANSFORM) $(BINARY)-darwin-arm64
+	cd build; tar -czf $(BINARY)-linux-amd64.tar.gz $(TAR_TRANSFORM) $(BINARY)-linux-amd64
+	cd build; tar -czf $(BINARY)-linux-arm64.tar.gz $(TAR_TRANSFORM) $(BINARY)-linux-arm64
+	cd build; tar -czf $(BINARY)-windows-amd64.tar.gz $(WIN_TAR_TRANSFORM) $(BINARY)-windows-amd64
 
 clean:
 	go clean

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 `spacectl` is distributed through GitHub Releases as a gzipped tarball containing a self-contained statically linked executable built from the source in this repository. Binaries can be download directly from the [Releases page](https://github.com/spacelift-io/spacectl/releases) or programmatically using `curl` or `wget`. The example below covers macOS (Intel CPU) installation of the latest available release. In order to download and install a Linux version, change `darwin` to `linux`. If you're using an ARM processor (eg. Raspberry Pi, Apple Silicon), change `amd64` to `arm64`:
 
 ```bash
-curl -s -L https://github.com/spacelift-io/spacectl/releases/latest/download/spacectl-darwin-amd64.tar.gz | tar xz -C /tmp && \
-mv /tmp/spacectl-darwin-amd64 /usr/local/bin/spacectl
+curl -s -L https://github.com/spacelift-io/spacectl/releases/latest/download/spacectl-darwin-amd64.tar.gz | sudo tar xz -C /usr/local/bin
 ```
 
 ## Authentication


### PR DESCRIPTION
- Added a tar transform that changes the architecture specific binary names (e.g. `spacectl-darwin-amd64`) to `spacectl` since the archive contains the architecture in the name. This means that you can just untar without having to rename the file afterwards.
- Used a specific transform for Windows that adds the `.exe` extension.