### PR TITLE
Run unit tests on GitHub Actions

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -1,0 +1,30 @@
+name: Unit testing
+
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+
+jobs:
+  unit-testing:
+    name: Test the code
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - windows-latest
+        - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@master
+            
+      - name: Install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Test the code
+        run: go test ./...

--- a/client/session/profile_manager_test.go
+++ b/client/session/profile_manager_test.go
@@ -72,11 +72,13 @@ func TestProfileManager(t *testing.T) {
 					},
 				}
 
-				manager.Create(testProfile)
+				err := manager.Create(testProfile)
+				Expect(err).To(BeNil())
 
 				currentProfile, err := manager.Current()
 
 				Expect(err).To(BeNil())
+				Expect(currentProfile).NotTo(BeNil())
 				Expect(currentProfile.Alias).To(Equal(testProfile.Alias))
 			})
 
@@ -262,6 +264,7 @@ func TestProfileManager(t *testing.T) {
 				manager.Select("profile1")
 
 				currentProfile, _ := manager.Current()
+				Expect(currentProfile).NotTo(BeNil())
 				Expect(currentProfile.Alias).To(Equal("profile1"))
 			})
 


### PR DESCRIPTION
- Added a new workflow to run unit tests. I've configured it to run on Linux, Windows and MacOS so we can have confidence the tool works on all of them.
- I've added some extra assertions to the profile tests to give us better output when they fail. Previously it was just segfaulting on Windows because of #8.