### PR TITLE
Store profiles in a single json file

### DIFF
--- a/client/session/from_current_profile.go
+++ b/client/session/from_current_profile.go
@@ -21,11 +21,7 @@ func FromCurrentProfile(ctx context.Context, client *http.Client) (Session, erro
 		return nil, fmt.Errorf("could not create profile manager: %w", err)
 	}
 
-	currentProfile, err := manager.Current()
-	if err != nil {
-		return nil, fmt.Errorf("could not load current profile: %w", err)
-	}
-
+	currentProfile := manager.Current()
 	if currentProfile == nil {
 		return nil, errors.New("no current profile is set - please login first")
 	}

--- a/client/session/profile_manager_test.go
+++ b/client/session/profile_manager_test.go
@@ -53,10 +53,9 @@ func TestProfileManager(t *testing.T) {
 		g.Describe("Current", func() {
 			g.Describe("no profiles exist", func() {
 				g.It("returns nil", func() {
-					profile, err := manager.Current()
+					profile := manager.Current()
 
 					Expect(profile).To(BeNil())
-					Expect(err).To(BeNil())
 				})
 			})
 		})
@@ -75,9 +74,8 @@ func TestProfileManager(t *testing.T) {
 				err := manager.Create(testProfile)
 				Expect(err).To(BeNil())
 
-				currentProfile, err := manager.Current()
+				currentProfile := manager.Current()
 
-				Expect(err).To(BeNil())
 				Expect(currentProfile).NotTo(BeNil())
 				Expect(currentProfile.Alias).To(Equal(testProfile.Alias))
 			})
@@ -242,11 +240,12 @@ func TestProfileManager(t *testing.T) {
 				Expect(testProfile.Alias).To(Equal(profileAlias))
 			})
 
-			g.It("returns error if profile file does not exist", func() {
+			g.It("returns nil if profile does not exist", func() {
 				profileAlias := "non-existent"
-				_, err := manager.Get(profileAlias)
+				profile, err := manager.Get(profileAlias)
 
-				Expect(err).Should(MatchError(fmt.Sprintf("a profile named '%s' could not be found", profileAlias)))
+				Expect(err).Should(BeNil())
+				Expect(profile).Should(BeNil())
 			})
 
 			g.It("returns error if profile alias is empty", func() {
@@ -263,7 +262,7 @@ func TestProfileManager(t *testing.T) {
 
 				manager.Select("profile1")
 
-				currentProfile, _ := manager.Current()
+				currentProfile := manager.Current()
 				Expect(currentProfile).NotTo(BeNil())
 				Expect(currentProfile.Alias).To(Equal("profile1"))
 			})
@@ -283,8 +282,9 @@ func TestProfileManager(t *testing.T) {
 
 				manager.Delete("profile1")
 
-				_, err := os.Stat(manager.ProfilePath("profile1"))
-				Expect(os.IsNotExist(err)).To(BeTrue())
+				profile, err := manager.Get("profile1")
+				Expect(err).To(BeNil())
+				Expect(profile).To(BeNil())
 			})
 
 			g.It("returns error if profile does not exist", func() {
@@ -304,8 +304,8 @@ func TestProfileManager(t *testing.T) {
 
 				manager.Delete("profile1")
 
-				_, err := os.Lstat(manager.CurrentPath)
-				Expect(os.IsNotExist(err)).To(BeTrue())
+				current := manager.Current()
+				Expect(current).To(BeNil())
 			})
 
 			g.It("does not unset profile if it is not the current profile", func() {
@@ -314,16 +314,16 @@ func TestProfileManager(t *testing.T) {
 
 				manager.Delete("profile1")
 
-				_, err := os.Lstat(manager.CurrentPath)
-				Expect(err).To(BeNil())
+				current := manager.Current()
+				Expect(current).NotTo(BeNil())
+				Expect(current.Alias).To(Equal("profile2"))
 			})
 		})
 
 		g.Describe("GetAll", func() {
 			g.It("returns empty when no profiles exist", func() {
-				profiles, err := manager.GetAll()
+				profiles := manager.GetAll()
 
-				Expect(err).To(BeNil())
 				Expect(profiles).To(BeEmpty())
 			})
 
@@ -332,7 +332,7 @@ func TestProfileManager(t *testing.T) {
 				manager.Create(createValidProfile("profile-2"))
 				manager.Create(createValidProfile("profile-3"))
 
-				profiles, _ := manager.GetAll()
+				profiles := manager.GetAll()
 
 				// Sort the slice to guarantee the order when comparing the results
 				sort.SliceStable(profiles, func(i int, j int) bool {

--- a/internal/cmd/profile/current_command.go
+++ b/internal/cmd/profile/current_command.go
@@ -16,10 +16,7 @@ func currentCommand() *cli.Command {
 		// doesn't accept any arguments
 		ArgsUsage: " ",
 		Action: func(ctx *cli.Context) error {
-			currentProfile, err := manager.Current()
-			if err != nil {
-				return fmt.Errorf("could not get current profile: %w", err)
-			}
+			currentProfile := manager.Current()
 
 			if currentProfile == nil {
 				return errors.New("no account is currently selected")

--- a/internal/cmd/profile/list_command.go
+++ b/internal/cmd/profile/list_command.go
@@ -1,7 +1,6 @@
 package profile
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/pterm/pterm"
@@ -16,15 +15,9 @@ func listCommand() *cli.Command {
 		Usage:     "List all your Spacelift account profiles",
 		ArgsUsage: " ",
 		Action: func(*cli.Context) error {
-			profiles, err := manager.GetAll()
-			if err != nil {
-				return fmt.Errorf("could not load Spacelift profiles: %w", err)
-			}
+			profiles := manager.GetAll()
 
-			currentProfile, err := manager.Current()
-			if err != nil {
-				return fmt.Errorf("could not get current profile: %w", err)
-			}
+			currentProfile := manager.Current()
 
 			// Make sure we output the profiles in a consistent order
 			sort.SliceStable(profiles, func(i int, j int) bool {

--- a/internal/cmd/profile/list_command.go
+++ b/internal/cmd/profile/list_command.go
@@ -44,7 +44,7 @@ func listCommand() *cli.Command {
 }
 
 func getCurrentProfileString(profile *session.Profile, currentProfile *session.Profile) string {
-	if profile.Alias == currentProfile.Alias {
+	if currentProfile != nil && profile.Alias == currentProfile.Alias {
 		return "*"
 	}
 


### PR DESCRIPTION
Using symlinks to point at the current profile doesn't work for Windows because it requires elevated permissions to create symlinks. Because of that I've refactored the code to store the profiles in a config.json file that also contains the name of the current profile.

In addition I've fixed a crash in the `profile list` command where it didn't check if the current profile was set or not.

**This is a breaking change - profiles stored up until now won't work anymore**