### PR TITLE
Remove curl instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@
 
 ## Installation
 
-`spacectl` is distributed through GitHub Releases as a gzipped tarball containing a self-contained statically linked executable built from the source in this repository. Binaries can be download directly from the [Releases page](https://github.com/spacelift-io/spacectl/releases) or programmatically using `curl` or `wget`. The example below covers macOS (Intel CPU) installation of the latest available release. In order to download and install a Linux version, change `darwin` to `linux`. If you're using an ARM processor (eg. Raspberry Pi, Apple Silicon), change `amd64` to `arm64`:
-
-```bash
-curl -s -L https://github.com/spacelift-io/spacectl/releases/latest/download/spacectl-darwin-amd64.tar.gz | sudo tar xz -C /usr/local/bin
-```
+`spacectl` is distributed through GitHub Releases as a zip file containing a self-contained statically linked executable built from the source in this repository. Binaries can be download directly from the [Releases page](https://github.com/spacelift-io/spacectl/releases).
 
 ## Authentication
 


### PR DESCRIPTION
Until we can come up with a static URL that can be used to download spacectl, just point users to the releases page.

Issue: #17