### PR TITLE
Improve usage information

### DIFF
--- a/internal/cmd/constants.go
+++ b/internal/cmd/constants.go
@@ -1,0 +1,5 @@
+package cmd
+
+// EmptyArgsUsage is used to specify that the command arguments section shouldn't be displayed
+// in the help text. This is a workaround to avoid having to change the entire template.
+const EmptyArgsUsage = " "

--- a/internal/cmd/profile/current_command.go
+++ b/internal/cmd/profile/current_command.go
@@ -4,17 +4,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/urfave/cli/v2"
 )
 
 func currentCommand() *cli.Command {
 	return &cli.Command{
-		Name:  "current",
-		Usage: "Outputs your currently selected profile",
-
-		// Use a space to cause the args usage to not be displayed since the `current` command
-		// doesn't accept any arguments
-		ArgsUsage: " ",
+		Name:      "current",
+		Usage:     "Outputs your currently selected profile",
+		ArgsUsage: cmd.EmptyArgsUsage,
 		Action: func(ctx *cli.Context) error {
 			currentProfile := manager.Current()
 

--- a/internal/cmd/profile/list_command.go
+++ b/internal/cmd/profile/list_command.go
@@ -7,13 +7,14 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/spacelift-io/spacectl/client/session"
+	"github.com/spacelift-io/spacectl/internal/cmd"
 )
 
 func listCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "list",
 		Usage:     "List all your Spacelift account profiles",
-		ArgsUsage: " ",
+		ArgsUsage: cmd.EmptyArgsUsage,
 		Action: func(*cli.Context) error {
 			profiles := manager.GetAll()
 

--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -4,7 +4,7 @@ import "github.com/urfave/cli/v2"
 
 var flagStackID = &cli.StringFlag{
 	Name:     "id",
-	Usage:    "User-facing `ID` (slug) of the stack",
+	Usage:    "[Required] User-facing `ID` (slug) of the stack",
 	Required: true,
 }
 
@@ -21,13 +21,13 @@ var flagNoFindRepositoryRoot = &cli.BoolFlag{
 
 var flagRequiredCommitSHA = &cli.StringFlag{
 	Name:     "sha",
-	Usage:    "`SHA` of the commit to set as canonical for the stack",
+	Usage:    "[Required] `SHA` of the commit to set as canonical for the stack",
 	Required: true,
 }
 
 var flagRun = &cli.StringFlag{
 	Name:     "run",
-	Usage:    "`ID` of the run",
+	Usage:    "[Required] `ID` of the run",
 	Required: true,
 }
 

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
@@ -24,8 +25,9 @@ func Command() *cli.Command {
 					flagRunMetadata,
 					flagTail,
 				},
-				Action: runConfirm(),
-				Before: authenticated.Ensure,
+				Action:    runConfirm(),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
@@ -37,8 +39,9 @@ func Command() *cli.Command {
 					flagRunMetadata,
 					flagTail,
 				},
-				Action: runTrigger("TRACKED", "deployment"),
-				Before: authenticated.Ensure,
+				Action:    runTrigger("TRACKED", "deployment"),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run local preview",
@@ -50,8 +53,9 @@ func Command() *cli.Command {
 					flagRunMetadata,
 					flagNoTail,
 				},
-				Action: localPreview(),
-				Before: authenticated.Ensure,
+				Action:    localPreview(),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
@@ -66,7 +70,8 @@ func Command() *cli.Command {
 					_, err := runLogs(context.Background(), stackID, cliCtx.String(flagRun.Name))
 					return err
 				},
-				Before: authenticated.Ensure,
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
@@ -78,8 +83,9 @@ func Command() *cli.Command {
 					flagRunMetadata,
 					flagTail,
 				},
-				Action: runTrigger("PROPOSED", "preview"),
-				Before: authenticated.Ensure,
+				Action:    runTrigger("PROPOSED", "preview"),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Stack management",
@@ -89,8 +95,9 @@ func Command() *cli.Command {
 					flagStackID,
 					flagRequiredCommitSHA,
 				},
-				Action: setCurrentCommit,
-				Before: authenticated.Ensure,
+				Action:    setCurrentCommit,
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
@@ -102,8 +109,9 @@ func Command() *cli.Command {
 					flagRunMetadata,
 					flagTail,
 				},
-				Action: taskCommand,
-				Before: authenticated.Ensure,
+				Action:    taskCommand,
+				Before:    authenticated.Ensure,
+				ArgsUsage: "COMMAND",
 			},
 		},
 	}


### PR DESCRIPTION
- Marked required flags with `[Required]`.
- Removed the arguments section from the usage info for commands that take no arguments.
- Updated the usage for the `stack task` command.

Issues: #19

I don't think we can really update the README right now until the changes are being released, otherwise it won't match the currently released version.

Here's an example of what the usage for the `stack confirm` command looks like now:

```shell
spacectl stack confirm --help
NAME:
   spacectl stack confirm - Confirm an unconfirmed tracked run

USAGE:
   spacectl stack confirm [command options]  

CATEGORY:
   Run management

OPTIONS:
   --id ID               [Required] User-facing ID (slug) of the stack
   --run ID              [Required] ID of the run
   --run-metadata value  Additional opaque metadata you will be able to access from policies handling this Run.
   --tail                Indicate whether to tail the run (default: false)
   --help, -h            show help (default: false)
```