### PR TITLE
Output profiles as JSON

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+// FlagOutputFormat allows users to change the output format of commands that support it.
+var FlagOutputFormat = &cli.StringFlag{
+	Name:    "output",
+	Aliases: []string{"o"},
+	Usage:   fmt.Sprintf("Output `format`. Allowed values: %s", strings.Join(AvailableOutputFormatStrings, ", ")),
+	Value:   string(OutputFormatTable),
+}

--- a/internal/cmd/output_format.go
+++ b/internal/cmd/output_format.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/urfave/cli/v2"
+)
+
+// OutputFormat defines the way that the results of a command are output to the user.
+type OutputFormat string
+
+const (
+	// OutputFormatTable represents the output formatted in a table.
+	OutputFormatTable OutputFormat = "table"
+
+	// OutputFormatJSON represents the output formatted as JSON.
+	OutputFormatJSON OutputFormat = "json"
+)
+
+// AvailableOutputFormatStrings returns all the output formats available to users.
+var AvailableOutputFormatStrings = []string{string(OutputFormatTable), string(OutputFormatJSON)}
+
+// GetOutputFormat gets the selected output format based on the CLI args.
+func GetOutputFormat(cliContext *cli.Context) (OutputFormat, error) {
+	format := cliContext.String(FlagOutputFormat.Name)
+	if format == "" || strings.EqualFold(format, string(OutputFormatTable)) {
+		return OutputFormatTable, nil
+	}
+
+	if strings.EqualFold(format, string(OutputFormatJSON)) {
+		return OutputFormatJSON, nil
+	}
+
+	return OutputFormatTable, fmt.Errorf("unknown output format: %s", format)
+}
+
+// OutputTable outputs the specified data as a table.
+func OutputTable(data [][]string) error {
+	return pterm.
+		DefaultTable.
+		WithHasHeader().
+		WithData(data).
+		Render()
+}
+
+// OutputJSON outputs the specified object as JSON.
+func OutputJSON(v interface{}) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(v); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/cmd/profile/list_command.go
+++ b/internal/cmd/profile/list_command.go
@@ -1,21 +1,31 @@
 package profile
 
 import (
+	"fmt"
 	"sort"
 
-	"github.com/pterm/pterm"
 	"github.com/urfave/cli/v2"
 
 	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/spacelift-io/spacectl/internal/cmd"
 )
 
+type profileListOutput struct {
+	Current  bool   `json:"current"`
+	Alias    string `json:"alias"`
+	Endpoint string `json:"endpoint"`
+	Type     string `json:"type"`
+}
+
 func listCommand() *cli.Command {
 	return &cli.Command{
-		Name:      "list",
-		Usage:     "List all your Spacelift account profiles",
+		Name:  "list",
+		Usage: "List all your Spacelift account profiles",
+		Flags: []cli.Flag{
+			cmd.FlagOutputFormat,
+		},
 		ArgsUsage: cmd.EmptyArgsUsage,
-		Action: func(*cli.Context) error {
+		Action: func(ctx *cli.Context) error {
 			profiles := manager.GetAll()
 
 			currentProfile := manager.Current()
@@ -25,27 +35,52 @@ func listCommand() *cli.Command {
 				return profiles[i].Alias < profiles[j].Alias
 			})
 
-			tableData := [][]string{{"Current", "Alias", "Endpoint", "Type"}}
-			for _, profile := range profiles {
-				tableData = append(tableData, []string{
-					getCurrentProfileString(profile, currentProfile),
-					profile.Alias,
-					profile.Credentials.Endpoint,
-					profile.Credentials.Type.String(),
-				})
+			var outputFormat cmd.OutputFormat
+			var err error
+			if outputFormat, err = cmd.GetOutputFormat(ctx); err != nil {
+				return err
 			}
 
-			return pterm.
-				DefaultTable.
-				WithHasHeader().
-				WithData(tableData).
-				Render()
+			switch outputFormat {
+			case cmd.OutputFormatTable:
+				tableData := [][]string{{"Current", "Alias", "Endpoint", "Type"}}
+				for _, profile := range profiles {
+					tableData = append(tableData, []string{
+						getCurrentProfileString(profile, currentProfile),
+						profile.Alias,
+						profile.Credentials.Endpoint,
+						profile.Credentials.Type.String(),
+					})
+				}
+
+				return cmd.OutputTable(tableData)
+
+			case cmd.OutputFormatJSON:
+				var profileList []profileListOutput
+
+				for _, profile := range profiles {
+					profileList = append(profileList, profileListOutput{
+						Current:  isCurrentProfile(profile, currentProfile),
+						Alias:    profile.Alias,
+						Endpoint: profile.Credentials.Endpoint,
+						Type:     profile.Credentials.Type.String(),
+					})
+				}
+
+				return cmd.OutputJSON(&profileList)
+			}
+
+			return fmt.Errorf("unknown output format: %v", outputFormat)
 		},
 	}
 }
 
+func isCurrentProfile(profile *session.Profile, currentProfile *session.Profile) bool {
+	return currentProfile != nil && profile.Alias == currentProfile.Alias
+}
+
 func getCurrentProfileString(profile *session.Profile, currentProfile *session.Profile) string {
-	if currentProfile != nil && profile.Alias == currentProfile.Alias {
+	if isCurrentProfile(profile, currentProfile) {
 		return "*"
 	}
 


### PR DESCRIPTION
Added an `--output` flag that allows users to choose between table and JSON output for the `profile list` command.

![image](https://user-images.githubusercontent.com/1884632/125056274-f92f9880-e09f-11eb-8925-0e8531f57cbf.png)
