### PR TITLE
Add a `stack show` command

### DIFF
--- a/internal/cmd/humanize.go
+++ b/internal/cmd/humanize.go
@@ -1,0 +1,45 @@
+package cmd
+
+// HumanizeVCSProvider converts the GraphQL VCSProvider enum to a human readable string.
+func HumanizeVCSProvider(provider string) string {
+	switch provider {
+	case "BITBUCKET_CLOUD":
+		return "Bitbucket Cloud"
+	case "BITBUCKET_DATACENTER":
+		return "Bitbucket Datacenter"
+	case "GITHUB":
+		return "GitHub"
+	case "GITLAB":
+		return "GitLab"
+	case "GITHUB_ENTERPRISE":
+		return "GitHub Enterprise"
+	case "SHOWCASE":
+		return "Showcase"
+	case "AZURE_DEVOPS":
+		return "Azure DevOps"
+	}
+
+	return provider
+}
+
+// HumanizePolicyType converts the GraphQL PolicyType enum to a human readable string.
+func HumanizePolicyType(policyType string) string {
+	switch policyType {
+	case "ACCESS":
+		return "Access"
+	case "LOGIN":
+		return "Login"
+	case "GIT_PUSH":
+		return "Git push"
+	case "INITIALIZATION":
+		return "Initialization"
+	case "PLAN":
+		return "Plan"
+	case "TASK":
+		return "Task"
+	case "TRIGGER":
+		return "Trigger"
+	}
+
+	return policyType
+}

--- a/internal/cmd/output_format.go
+++ b/internal/cmd/output_format.go
@@ -39,12 +39,16 @@ func GetOutputFormat(cliContext *cli.Context) (OutputFormat, error) {
 }
 
 // OutputTable outputs the specified data as a table.
-func OutputTable(data [][]string) error {
-	return pterm.
+func OutputTable(data [][]string, hasHeader bool) error {
+	printer := pterm.
 		DefaultTable.
-		WithHasHeader().
-		WithData(data).
-		Render()
+		WithData(data)
+
+	if hasHeader {
+		printer = printer.WithHasHeader()
+	}
+
+	return printer.Render()
 }
 
 // OutputJSON outputs the specified object as JSON.

--- a/internal/cmd/profile/list_command.go
+++ b/internal/cmd/profile/list_command.go
@@ -53,7 +53,7 @@ func listCommand() *cli.Command {
 					})
 				}
 
-				return cmd.OutputTable(tableData)
+				return cmd.OutputTable(tableData, true)
 
 			case cmd.OutputFormatJSON:
 				var profileList []profileListOutput

--- a/internal/cmd/stack/list.go
+++ b/internal/cmd/stack/list.go
@@ -134,5 +134,5 @@ func listStacksTable(ctx context.Context) error {
 		})
 	}
 
-	return cmd.OutputTable(tableData)
+	return cmd.OutputTable(tableData, true)
 }

--- a/internal/cmd/stack/show.go
+++ b/internal/cmd/stack/show.go
@@ -1,0 +1,356 @@
+package stack
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
+	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd"
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+)
+
+const (
+	stackConfigVendorPulumi    = "StackConfigVendorPulumi"
+	stackConfigVendorTerraform = "StackConfigVendorTerraform"
+)
+
+type stackConfigElement struct {
+	ID        string `graphql:"id" json:"id,omitempty"`
+	Checksum  string `graphql:"checksum" json:"checksum,omitempty"`
+	Runtime   bool   `graphql:"runtime" json:"runtime"`
+	Type      string `graphql:"type" json:"type,omitempty"`
+	WriteOnly bool   `graphql:"writeOnly" json:"writeOnly"`
+}
+
+type showStackQuery struct {
+	Stack *struct {
+		ID               string `graphql:"id" json:"id,omitempty"`
+		Administrative   bool   `graphql:"administrative" json:"administrative"`
+		AttachedContexts []struct {
+			ContextID string               `graphql:"contextId" json:"contextId,omitempty"`
+			Name      string               `graphql:"contextName" json:"name,omitempty"`
+			Priority  int                  `graphql:"priority" json:"priority,omitempty"`
+			Config    []stackConfigElement `graphql:"config" json:"config,omitempty"`
+		} `graphql:"attachedContexts"`
+		AttachedPolicies []struct {
+			PolicyID string `graphql:"policyId" json:"policyId,omitempty"`
+			Name     string `graphql:"policyName" json:"name,omitempty"`
+			Type     string `graphql:"policyType" json:"type,omitempty"`
+		} `graphql:"attachedPolicies"`
+		Autodeploy bool `graphql:"autodeploy" json:"autodeploy"`
+		Autoretry  bool `graphql:"autoretry" json:"autoretry"`
+		Blocker    struct {
+			ID string `graphql:"id" json:"id,omitempty"`
+		} `graphql:"blocker"`
+		AfterApply          []string             `graphql:"afterApply" json:"afterApply,omitempty"`
+		BeforeApply         []string             `graphql:"beforeApply" json:"beforeApply,omitempty"`
+		AfterInit           []string             `graphql:"afterInit" json:"afterInit,omitempty"`
+		BeforeInit          []string             `graphql:"beforeInit" json:"beforeInit,omitempty"`
+		AfterPlan           []string             `graphql:"afterPlan" json:"afterPlan,omitempty"`
+		BeforePlan          []string             `graphql:"beforePlan" json:"beforePlan,omitempty"`
+		AfterPerform        []string             `graphql:"afterPerform" json:"afterPerform,omitempty"`
+		BeforePerform       []string             `graphql:"beforePerform" json:"beforePerform,omitempty"`
+		AfterDestroy        []string             `graphql:"afterDestroy" json:"afterDestroy,omitempty"`
+		BeforeDestroy       []string             `graphql:"beforeDestroy" json:"beforeDestroy,omitempty"`
+		Branch              string               `graphql:"branch" json:"branch,omitempty"`
+		CanWrite            bool                 `graphql:"canWrite" json:"canWrite"`
+		Config              []stackConfigElement `graphql:"config" json:"config,omitempty"`
+		CreatedAt           int64                `graphql:"createdAt" json:"createdAt,omitempty"`
+		Deleted             bool                 `graphql:"deleted" json:"deleted"`
+		Deleting            bool                 `graphql:"deleting" json:"deleting"`
+		Description         string               `graphql:"description" json:"description,omitempty"`
+		Labels              []string             `graphql:"labels" json:"labels,omitempty"`
+		LocalPreviewEnabled bool                 `graphql:"localPreviewEnabled" json:"localPreviewEnabled"`
+		LockedBy            string               `graphql:"lockedBy" json:"lockedBy,omitempty"`
+		ManagesStateFile    bool                 `graphql:"managesStateFile" json:"managesStateFile"`
+		ModuleVersionsUsed  []struct {
+			ID     string `graphql:"id" json:"id,omitempty"`
+			Number string `graphql:"number" json:"number,omitempty"`
+			Module struct {
+				ID   string `graphql:"id" json:"id,omitempty"`
+				Name string `graphql:"name" json:"name,omitempty"`
+			} `graphql:"module" json:"module"`
+		} `graphql:"moduleVersionsUsed" json:"moduleVersionsUsed,omitempty"`
+		Name             string `graphql:"name" json:"name,omitempty"`
+		Namespace        string `graphql:"namespace" json:"namespace,omitempty"`
+		ProjectRoot      string `graphql:"projectRoot" json:"projectRoot,omitempty"`
+		Provider         string `graphql:"provider" json:"provider,omitempty"`
+		Repository       string `graphql:"repository" json:"repository,omitempty"`
+		RunnerImage      string `graphql:"runnerImage" json:"runnerImage,omitempty"`
+		Starred          bool   `graphql:"starred" json:"starred"`
+		State            string `graphql:"state" json:"state,omitempty"`
+		StateSetAt       int64  `graphql:"stateSetAt" json:"stateSetAt,omitempty"`
+		TerraformVersion string `graphql:"terraformVersion" json:"terraformVersion,omitempty"`
+		TrackedCommit    struct {
+			AuthorLogin string `graphql:"authorLogin" json:"authorLogin,omitempty"`
+			AuthorName  string `graphql:"authorName" json:"authorName,omitempty"`
+			Hash        string `graphql:"hash" json:"hash,omitempty"`
+			Message     string `graphql:"message" json:"message,omitempty"`
+			Timestamp   int64  `graphql:"timestamp" json:"timestamp,omitempty"`
+			URL         string `graphql:"url" json:"url,omitempty"`
+		} `graphql:"trackedCommit" json:"trackedCommit,omitempty"`
+		TrackedCommitSetBy string `graphql:"trackedCommitSetBy" json:"trackedCommitSetBy,omitempty"`
+		VendorConfig       struct {
+			Vendor string `graphql:"__typename"`
+			Pulumi struct {
+				LoginURL  string `graphql:"loginURL"`
+				StackName string `graphql:"stackName"`
+			} `graphql:"... on StackConfigVendorPulumi"`
+			Terraform struct {
+				Version   string `graphql:"version"`
+				Workspace string `graphql:"workspace"`
+			} `graphql:"... on StackConfigVendorTerraform"`
+		} `graphql:"vendorConfig"`
+		WorkerPool struct {
+			ID   string `graphql:"id" json:"id,omitempty"`
+			Name string `graphql:"name" json:"name,omitempty"`
+		} `graphql:"workerPool" json:"workerPool,omitempty"`
+	} `graphql:"stack(id: $stackId)" json:"stacks,omitempty"`
+}
+
+type showStackCommand struct{}
+
+func (c *showStackCommand) showStack(cliCtx *cli.Context) error {
+	stackID := cliCtx.String(flagStackID.Name)
+
+	outputFormat, err := cmd.GetOutputFormat(cliCtx)
+	if err != nil {
+		return err
+	}
+
+	var query showStackQuery
+	variables := map[string]interface{}{
+		"stackId": graphql.ID(stackID),
+	}
+
+	if err := authenticated.Client.Query(cliCtx.Context, &query, variables); err != nil {
+		return errors.Wrapf(err, "failed to query for stack ID %q", stackID)
+	}
+
+	if query.Stack == nil {
+		return fmt.Errorf("stack ID %q not found", stackID)
+	}
+
+	switch outputFormat {
+	case cmd.OutputFormatTable:
+		return c.showStackTable(query)
+	case cmd.OutputFormatJSON:
+		return cmd.OutputJSON(query.Stack)
+	}
+
+	return fmt.Errorf("unknown output format: %v", outputFormat)
+}
+
+func (c *showStackCommand) showStackTable(query showStackQuery) error {
+	c.outputStackNameSection(query)
+	if err := c.outputVCSSettings(query); err != nil {
+		return err
+	}
+	if err := c.outputBackendSettings(query); err != nil {
+		return err
+	}
+	if err := c.outputBehaviorSettings(query); err != nil {
+		return err
+	}
+	if err := c.outputContexts(query); err != nil {
+		return err
+	}
+	if err := c.outputPolicies(query); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *showStackCommand) outputStackNameSection(query showStackQuery) {
+	pterm.DefaultSection.WithLevel(1).Print(query.Stack.Name)
+
+	if len(query.Stack.Labels) > 0 {
+		pterm.DefaultSection.WithLevel(2).Println("Labels")
+		pterm.DefaultParagraph.Println(fmt.Sprintf("[%s]", strings.Join(query.Stack.Labels, "], [")))
+	}
+
+	if query.Stack.Description != "" {
+		pterm.DefaultSection.WithLevel(2).Println("Description")
+		pterm.DefaultParagraph.Println(query.Stack.Description)
+	}
+}
+
+func (c *showStackCommand) outputVCSSettings(query showStackQuery) error {
+	pterm.DefaultSection.WithLevel(2).Println("VCS Settings")
+	tableData := [][]string{
+		{"Provider", cmd.HumanizeVCSProvider(query.Stack.Provider)},
+		{"Repository", query.Stack.Repository},
+		{"Branch", query.Stack.Branch},
+	}
+
+	return cmd.OutputTable(tableData, false)
+}
+
+func (c *showStackCommand) outputBackendSettings(query showStackQuery) error {
+	pterm.DefaultSection.WithLevel(2).Println("Backend")
+	tableData := [][]string{
+		{"Vendor", c.humanizeVendor(query.Stack.VendorConfig.Vendor)},
+	}
+
+	if query.Stack.VendorConfig.Vendor == stackConfigVendorPulumi {
+		tableData = append(tableData, []string{"Login URL", query.Stack.VendorConfig.Pulumi.LoginURL})
+		tableData = append(tableData, []string{"Stack name", query.Stack.VendorConfig.Pulumi.StackName})
+	} else if query.Stack.VendorConfig.Vendor == stackConfigVendorTerraform {
+		if !query.Stack.ManagesStateFile {
+			tableData = append(tableData, []string{"Workspace", fmt.Sprint(query.Stack.VendorConfig.Terraform.Workspace)})
+		}
+		tableData = append(tableData, []string{"Version", stringWithDefault(query.Stack.VendorConfig.Terraform.Version, "latest")})
+		tableData = append(tableData, []string{"Managed state", fmt.Sprint(query.Stack.ManagesStateFile)})
+	}
+
+	return cmd.OutputTable(tableData, false)
+}
+
+func (c *showStackCommand) outputBehaviorSettings(query showStackQuery) error {
+	pterm.DefaultSection.WithLevel(2).Println("VCS Settings")
+
+	workerPoolText := "Using shared public worker pool"
+	if query.Stack.WorkerPool.ID != "" {
+		workerPoolText = fmt.Sprintf("%s (%s)", query.Stack.WorkerPool.Name, query.Stack.WorkerPool.ID)
+	}
+
+	tableData := [][]string{
+		{"Administrative", fmt.Sprint(query.Stack.Administrative)},
+		{"Worker pool", workerPoolText},
+		{"Autodeploy", fmt.Sprint(query.Stack.Autodeploy)},
+		{"Autoretry", fmt.Sprint(query.Stack.Autoretry)},
+		{"Local preview enabled", fmt.Sprint(query.Stack.LocalPreviewEnabled)},
+		{"Project root", fmt.Sprint(query.Stack.ProjectRoot)},
+		{"Runner image", stringWithDefault(query.Stack.RunnerImage, "default")},
+	}
+
+	if err := cmd.OutputTable(tableData, false); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.BeforeInit, "Before init scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.AfterInit, "After init scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.BeforePlan, "Before plan scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.AfterPlan, "After plan scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.BeforeApply, "Before apply scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.AfterApply, "After apply scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.BeforePerform, "Before perform scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.AfterPerform, "After perform scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.BeforeDestroy, "Before destroy scripts"); err != nil {
+		return err
+	}
+
+	if err := c.outputScripts(query.Stack.AfterDestroy, "After destroy scripts"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *showStackCommand) outputContexts(query showStackQuery) error {
+	if len(query.Stack.AttachedContexts) == 0 {
+		return nil
+	}
+
+	pterm.DefaultSection.WithLevel(2).Println("Attached contexts")
+
+	sort.SliceStable(query.Stack.AttachedContexts, func(i, j int) bool {
+		return query.Stack.AttachedContexts[i].Priority < query.Stack.AttachedContexts[j].Priority
+	})
+
+	tableData := [][]string{{"Priority", "Name", "ID"}}
+	for _, context := range query.Stack.AttachedContexts {
+
+		tableData = append(tableData, []string{
+			fmt.Sprint(context.Priority),
+			context.Name,
+			context.ContextID,
+		})
+	}
+
+	return cmd.OutputTable(tableData, true)
+}
+
+func (c *showStackCommand) outputPolicies(query showStackQuery) error {
+	if len(query.Stack.AttachedPolicies) == 0 {
+		return nil
+	}
+
+	pterm.DefaultSection.WithLevel(2).Println("Attached policies")
+
+	tableData := [][]string{{"Name", "Type"}}
+	for _, policy := range query.Stack.AttachedPolicies {
+
+		tableData = append(tableData, []string{
+			policy.Name,
+			cmd.HumanizePolicyType(policy.Type),
+		})
+	}
+
+	return cmd.OutputTable(tableData, true)
+}
+
+func (c *showStackCommand) outputScripts(scripts []string, title string) error {
+	if len(scripts) > 0 {
+		pterm.DefaultSection.WithLevel(3).Println(title)
+		var items []pterm.BulletListItem
+		for _, script := range scripts {
+			items = append(items, pterm.BulletListItem{Level: 0, Text: script})
+		}
+
+		if err := pterm.DefaultBulletList.WithItems(items).Render(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *showStackCommand) humanizeVendor(vendorConfigType string) string {
+	switch vendorConfigType {
+	case stackConfigVendorPulumi:
+		return "Pulumi"
+	case stackConfigVendorTerraform:
+		return "Terraform"
+	}
+
+	return vendorConfigType
+}
+
+func stringWithDefault(value string, defaultValue string) string {
+	if value == "" {
+		return defaultValue
+	}
+
+	return value
+}

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -110,6 +110,17 @@ func Command() *cli.Command {
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
+				Name:  "show",
+				Usage: "Shows detailed information about a specific stack",
+				Flags: []cli.Flag{
+					flagStackID,
+					cmd.FlagOutputFormat,
+				},
+				Action:    (&showStackCommand{}).showStack,
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+			{
 				Category: "Run management",
 				Name:     "task",
 				Usage:    "Perform a task in a workspace",

--- a/specs/spacectl-to-v1.md
+++ b/specs/spacectl-to-v1.md
@@ -66,80 +66,80 @@ Because one of the use-cases is scripting, we want to be able to use the output 
 #### API Keys
 
 - `spacectl api-key`
-  - `list` - lists the API keys in your account
-  - `create` - creates an API key
-  - `delete` - deletes an API key
+  - [ ] `list` - lists the API keys in your account
+  - [ ] `create` - creates an API key
+  - [ ] `delete` - deletes an API key
 
 #### Audit Trail
 
 - `spacectl audit-trail`
-  - `show` - shows current audit trail settings
-  - `setup` - configures the audit trail
-  - `update` - allows you to update the webhooks endpoint, secret and status of the integration
+  - [ ] `show` - shows current audit trail settings
+  - [ ] `setup` - configures the audit trail
+  - [ ] `update` - allows you to update the webhooks endpoint, secret and status of the integration
 
 #### Modules
 
 We should support the following commands for working with Modules:
 
 - `spacectl module`
-  - `list` - lists the modules you have access to
-  - `add` - adds a new module
-  - `delete` - deletes a module
-  - `show` - outputs information about a specified module
-  - `edit` - edits the name, provider, labels and description for the module
+  - [ ] `list` - lists the modules you have access to
+  - [ ] `add` - adds a new module
+  - [ ] `delete` - deletes a module
+  - [ ] `show` - outputs information about a specified module
+  - [ ] `edit` - edits the name, provider, labels and description for the module
 
 Subcommands:
 
 - `spacectl module version`
-  - `list` - lists the versions for a specific module
-  - `create` - triggers a run to create a new version
-  - `show` - shows information about a module version
+  - [ ] `list` - lists the versions for a specific module
+  - [ ] `create` - triggers a run to create a new version
+  - [ ] `show` - shows information about a module version
 - `spacectl module pr`
-  - `list` - lists any open PRs against the module
-  - `show` - outputs information about a specified PR
+  - [ ] `list` - lists any open PRs against the module
+  - [ ] `show` - outputs information about a specified PR
 - `spacectl module environment`
-  - `show` - outputs the environment variables and attached contexts.
-  - `add` - adds a new environment variable or mounted file
-  - `edit` - updates an environment variable or mounted file
-  - `delete` - deletes an environment variable or mounted file
+  - [ ] `show` - outputs the environment variables and attached contexts.
+  - [ ] `add` - adds a new environment variable or mounted file
+  - [ ] `edit` - updates an environment variable or mounted file
+  - [ ] `delete` - deletes an environment variable or mounted file
 - `spacectl module vcs`
-  - `show` - show the module's VCS settings
-  - `edit` - edit the module's VCS settings
+  - [ ] `show` - show the module's VCS settings
+  - [ ] `edit` - edit the module's VCS settings
 - `spacectl module behavior`
-  - `show` - shows the module's behavior settings
-  - `edit` - edits the module's behavior settings
+  - [ ] `show` - shows the module's behavior settings
+  - [ ] `edit` - edits the module's behavior settings
 - `spacectl module context`
-  - `list` - lists the contexts attached to the module
-  - `attach` - attaches a context to the module
-  - `detach` - detaches a context from the module
+  - [ ] `list` - lists the contexts attached to the module
+  - [ ] `attach` - attaches a context to the module
+  - [ ] `detach` - detaches a context from the module
 - `spacectl module policy`
-  - `list` - lists the policies attached to the module
-  - `attach` - attaches a policy to the module
-  - `detach` - detaches a policy from the module
+  - [ ] `list` - lists the policies attached to the module
+  - [ ] `attach` - attaches a policy to the module
+  - [ ] `detach` - detaches a policy from the module
 - `spacectl module share`
-  - `list` - lists the accounts that the module is shared with
-  - `add` - adds an account to the list of shared accounts
-  - `remove` - removes an account from the list of shared accounts
+  - [ ] `list` - lists the accounts that the module is shared with
+  - [ ] `add` - adds an account to the list of shared accounts
+  - [ ] `remove` - removes an account from the list of shared accounts
 
 #### Policies
 
 We should support the following commands for working with policies:
 
 - `spacectl policy`
-  - `list` - lists the policies in the account
-  - `show` - shows the details of a specific policy
-  - `add` - adds a new policy
-  - `edit` - updated an existing policy
-  - `delete` - deletes a policy
+  - [ ] `list` - lists the policies in the account
+  - [ ] `show` - shows the details of a specific policy
+  - [ ] `add` - adds a new policy
+  - [ ] `edit` - updated an existing policy
+  - [ ] `delete` - deletes a policy
 
 #### Profile
 
 - `spacectl profile`
-  - `current` - shows the currently active profile
-  - `list` - lists available profiles
-  - `login` - creates a new profile
-  - `logout` - removes a profile
-  - `select` - selects one of your profiles as the current profile
+  - [ ] `current` - shows the currently active profile
+  - [ ] `list` - lists available profiles
+  - [ ] `login` - creates a new profile
+  - [ ] `logout` - removes a profile
+  - [ ] `select` - selects one of your profiles as the current profile
 
 #### Slack Settings
 
@@ -147,74 +147,74 @@ We should support the following commands for working with policies:
 settings other than viewing that it's configured and opening a browser to connect.
 
 - `spacectl slack`
-  - `show` - shows current integration settings
-  - `setup` - configures the Slack integration by launching the OAuth2 process
+  - [ ] `show` - shows current integration settings
+  - [ ] `setup` - configures the Slack integration by launching the OAuth2 process
 
 #### SSO Settings
 
 We should support the following commands for working with SSO settings.
 
 - `spacectl sso`
-  - `show` - show current SSO settings
-  - `setup` - configure the SSO settings for the account
-  - `delete` - deletes your SSO configuration
+  - [ ] `show` - show current SSO settings
+  - [ ] `setup` - configure the SSO settings for the account
+  - [ ] `delete` - deletes your SSO configuration
 
 #### Stacks
 
 We should support the following commands for working with Stacks:
 
 - `spacectl stack`
-  - `list` - lists the stacks you have access to
-  - `add` - adds a new stack
-  - `delete` - deletes a stack
-  - `show` - outputs information about a specified Stack
-  - `edit` - edits the name, labels and description for the stack
-  - `set-current-commit` - sets the current commit for the stack
+  - [x] `list` - lists the stacks you have access to
+  - [ ] `add` - adds a new stack
+  - [ ] `delete` - deletes a stack
+  - [ ] `show` - outputs information about a specified Stack
+  - [ ] `edit` - edits the name, labels and description for the stack
+  - [ ] `set-current-commit` - sets the current commit for the stack
 
 Subcommands:
 
 - `spacectl stack run`
-  - `confirm` - confirms a run awaiting approval
-  - `list` - lists the runs for your stack
-  - `trigger` - triggers a run
-  - `preview` - triggers a preview run for a specific commit
-  - `local-preview` - triggers a local-preview run using the current directory as the workspace
-  - `logs` - shows the logs for a run
-  - `show` - outputs information about a specified Run
+  - [ ] `confirm` - confirms a run awaiting approval
+  - [ ] `list` - lists the runs for your stack
+  - [ ] `trigger` - triggers a run
+  - [ ] `preview` - triggers a preview run for a specific commit
+  - [ ] `local-preview` - triggers a local-preview run using the current directory as the workspace
+  - [ ] `logs` - shows the logs for a run
+  - [ ] `show` - outputs information about a specified Run
 - `spacectl stack task`
-  - `list` - lists any tasks that have been run against the stack
-  - `perform` - performs a one-off task in a workspace
-  - `show` - outputs information about a specified Task
+  - [ ] `list` - lists any tasks that have been run against the stack
+  - [ ] `perform` - performs a one-off task in a workspace
+  - [ ] `show` - outputs information about a specified Task
 - `spacectl stack pr`
-  - `list` - lists any open PRs against the stack
-  - `show` - outputs information about a specified PR
+  - [ ] `list` - lists any open PRs against the stack
+  - [ ] `show` - outputs information about a specified PR
 - `spacectl stack environment`
-  - `show` - outputs the environment variables and attached contexts.
-  - `add` - adds a new environment variable or mounted file
-  - `edit` - updates an environment variable or mounted file
-  - `delete` - deletes an environment variable or mounted file
+  - [ ] `show` - outputs the environment variables and attached contexts.
+  - [ ] `add` - adds a new environment variable or mounted file
+  - [ ] `edit` - updates an environment variable or mounted file
+  - [ ] `delete` - deletes an environment variable or mounted file
 
 The following commands are all under the _settings_ section of the UI, but they aren't nested
 under a `settings` subcommand here to avoid too much command nesting. Alternatively we could
 just have a single settings command that does everything:
 
 - `spacectl stack vcs`
-  - `show` - show the stack's VCS settings
-  - `edit` - edit the stack's VCS settings
+  - [ ] `show` - show the stack's VCS settings
+  - [ ] `edit` - edit the stack's VCS settings
 - `spacectl stack backend`
-  - `show` - shows the stack's backend settings
-  - `edit` - edits the stack's backend settings
+  - [ ] `show` - shows the stack's backend settings
+  - [ ] `edit` - edits the stack's backend settings
 - `spacectl stack behavior`
-  - `show` - shows the stack's behavior settings
-  - `edit` - edits the stack's behavior settings
+  - [ ] `show` - shows the stack's behavior settings
+  - [ ] `edit` - edits the stack's behavior settings
 - `spacectl stack context`
-  - `list` - lists the contexts attached to the stack
-  - `attach` - attaches a context to the stack
-  - `detach` - detaches a context from the stack
+  - [ ] `list` - lists the contexts attached to the stack
+  - [ ] `attach` - attaches a context to the stack
+  - [ ] `detach` - detaches a context from the stack
 - `spacectl stack policy`
-  - `list` - lists the policies attached to the stack
-  - `attach` - attaches a policy to the stack
-  - `detach` - detaches a policy from the stack
+  - [ ] `list` - lists the policies attached to the stack
+  - [ ] `attach` - attaches a policy to the stack
+  - [ ] `detach` - detaches a policy from the stack
 
 **_Questions_**:
 
@@ -226,36 +226,36 @@ just have a single settings command that does everything:
 We should support the following commands for managing VCS agent pools:
 
 - `spacectl vcs-agent-pool`
-  - `list` - lists the VCS agent pools in the account
-  - `add` - adds a new VCS agent pool
-  - `show` - shows details of a specific agent pool
-  - `reset` - resets the credentials for an agent pool
-  - `delete` - deletes an agent pool
+  - [ ] `list` - lists the VCS agent pools in the account
+  - [ ] `add` - adds a new VCS agent pool
+  - [ ] `show` - shows details of a specific agent pool
+  - [ ] `reset` - resets the credentials for an agent pool
+  - [ ] `delete` - deletes an agent pool
 
 #### VCS Integrations
 
 We should support the following commands for managing VCS integrations.
 
 - `spacectl bitbucket cloud`
-  - `show` - show current integration settings
-  - `setup` - configures the Bitbucket integration
-  - `update` - allows you to update your username and password
-  - `unlink` - disables the integration and removes any settings
+  - [ ] `show` - show current integration settings
+  - [ ] `setup` - configures the Bitbucket integration
+  - [ ] `update` - allows you to update your username and password
+  - [ ] `unlink` - disables the integration and removes any settings
 - `spacectl bitbucket datacenter`
-  - `show` - show current integration settings
-  - `setup` - configures the Bitbucket integration
-  - `update` - allows you to update your API Host, user facing host, token or webhook secret
-  - `unlink` - disables the integration and removes any settings
+  - [ ] `show` - show current integration settings
+  - [ ] `setup` - configures the Bitbucket integration
+  - [ ] `update` - allows you to update your API Host, user facing host, token or webhook secret
+  - [ ] `unlink` - disables the integration and removes any settings
 - `spacectl github-enterprise`
-  - `show` - show current integration settings
-  - `setup` - configures the GitHub Enterprise integration
-  - `update` - allows you to update your API Host, private key or webhook secret
-  - `unlink` - disables the integration and removes any settings
+  - [ ] `show` - show current integration settings
+  - [ ] `setup` - configures the GitHub Enterprise integration
+  - [ ] `update` - allows you to update your API Host, private key or webhook secret
+  - [ ] `unlink` - disables the integration and removes any settings
 - `spacectl gitlab`
-  - `show` - show current integration settings
-  - `setup` - configures the GitLab integration
-  - `update` - allows you to update your API Host, token or webhook secret
-  - `unlink` - disables the integration and removes any settings
+  - [ ] `show` - show current integration settings
+  - [ ] `setup` - configures the GitLab integration
+  - [ ] `update` - allows you to update your API Host, token or webhook secret
+  - [ ] `unlink` - disables the integration and removes any settings
 
 **_Questions_**:
 
@@ -269,8 +269,8 @@ We should support the following commands for managing VCS integrations.
 We should support the following commands for managing worker pools:
 
 - `spacectl worker-pool`
-  - `list` - lists the worker pools in the account
-  - `add` - adds a new worker pool - `spacectl` could take care of the CSR part automatically
-  - `show` - shows details of a specific worker pool
-  - `reset` - resets the credentials for a worker pool
-  - `delete` - deletes a worker pool
+  - [ ] `list` - lists the worker pools in the account
+  - [ ] `add` - adds a new worker pool - `spacectl` could take care of the CSR part automatically
+  - [ ] `show` - shows details of a specific worker pool
+  - [ ] `reset` - resets the credentials for a worker pool
+  - [ ] `delete` - deletes a worker pool


### PR DESCRIPTION
Added a `spacectl stack show` command that outputs the settings for a specific stack. The JSON outputs pretty much all the stack information, but I've been pretty selective with what's output for the table format to keep the output relatively short (for example I'm not outputting all the context/environment values).

At the moment I also haven't added integrations and module version usage to the table view, just because I need to spend a bit time setting some up and testing them. I'll do that separately.

Here's a screencast showing the command in action:

[![asciicast](https://asciinema.org/a/nk8ZFDuM5SZXQfozuzdHISquD.svg)](https://asciinema.org/a/nk8ZFDuM5SZXQfozuzdHISquD)