### PR TITLE
Add support for Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,4 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,3 +34,13 @@ release:
 
 changelog:
   skip: true
+
+brews:
+  - name: "{{ .ProjectName }}"
+    tap:
+      owner: "spacelift-io"
+      name: "homebrew-spacelift"
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/spacelift-io/spacectl
+    description: "Spacelift client and CLI"
+    license: "MIT"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 ## Installation
 
-`spacectl` is distributed through GitHub Releases as a zip file containing a self-contained statically linked executable built from the source in this repository. Binaries can be download directly from the [Releases page](https://github.com/spacelift-io/spacectl/releases).
+You can install `spacectl` using Homebrew on MacOS or Linux:
+
+```bash
+brew install spacelift-io/spacelift/spacectl
+```
+
+Alternatively, `spacectl` is distributed through GitHub Releases as a zip file containing a self-contained statically linked executable built from the source in this repository. Binaries can be download directly from the [Releases page](https://github.com/spacelift-io/spacectl/releases).
 
 ## Quick Start
 


### PR DESCRIPTION
Initial attempt to make spacectl available via [Homebrew](https://brew.sh).