### PR TITLE
Profile subcommand to export bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ USAGE:
    spacectl profile command [command options] [arguments...]
 
 COMMANDS:
-   current  Outputs your currently selected profile
-   list     List all your Spacelift account profiles
-   login    Create a profile for a Spacelift account
-   logout   Remove Spacelift credentials for an existing profile
-   select   Select one of your Spacelift account profiles
-   help, h  Shows a list of commands or help for one command
+   current       Outputs your currently selected profile
+   export-token  Prints the current token to stdout. In order not to leak, we suggest piping it to your OS pastebin
+   list          List all your Spacelift account profiles
+   login         Create a profile for a Spacelift account
+   logout        Remove Spacelift credentials for an existing profile
+   select        Select one of your Spacelift account profiles
+   help, h       Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help (default: false)

--- a/internal/cmd/profile/export_token.go
+++ b/internal/cmd/profile/export_token.go
@@ -1,0 +1,42 @@
+package profile
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd"
+)
+
+func exportTokenCommand() *cli.Command {
+	return &cli.Command{
+		Name: "export-token",
+		Usage: "Prints the current token to stdout. In order not to leak, " +
+			"we suggest piping it to your OS pastebin",
+		ArgsUsage: cmd.EmptyArgsUsage,
+		Action: func(ctx *cli.Context) error {
+			currentProfile := manager.Current()
+			if currentProfile == nil {
+				return errors.New("no account is currently selected")
+			}
+
+			session, err := currentProfile.Credentials.Session(ctx.Context, http.DefaultClient)
+			if err != nil {
+				return fmt.Errorf("could not get session: %w", err)
+			}
+
+			token, err := session.BearerToken(ctx.Context)
+			if err != nil {
+				return fmt.Errorf("could not get bearer token: %w", err)
+			}
+
+			if _, err = fmt.Print(token); err != nil {
+				return fmt.Errorf("could not print token: %w", err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/cmd/profile/profile.go
+++ b/internal/cmd/profile/profile.go
@@ -27,13 +27,14 @@ func Command() *cli.Command {
 
 			configDir := filepath.Join(homeDir, session.SpaceliftConfigDirectory)
 			if manager, err = session.NewProfileManager(configDir); err != nil {
-				return fmt.Errorf("could not initialise profile manager: %w", err)
+				return fmt.Errorf("could not initialize profile manager: %w", err)
 			}
 
 			return nil
 		},
 		Subcommands: []*cli.Command{
 			currentCommand(),
+			exportTokenCommand(),
 			listCommand(),
 			loginCommand(),
 			logoutCommand(),


### PR DESCRIPTION
Exporting the raw token is useful for things like creating/updating `.terraformrc`, for custom scripts, or to be used with the GraphQL client.