### PR TITLE
Add a `--no-color` flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/franela/goblin v0.0.0-20210113153425-413781f5e6c8
 	github.com/gookit/color v1.4.2 // indirect
+	github.com/mattn/go-isatty v0.0.14
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/onsi/gomega v1.11.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,9 @@ github.com/marcinwyszynski/graphql v0.0.0-20210505073322-ed22d920d37d h1:9Z8P/yi
 github.com/marcinwyszynski/graphql v0.0.0-20210505073322-ed22d920d37d/go.mod h1:arY+KAJGvLcmVrvOSx+bDyXcfKl4+eurb19qg+FYX08=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
@@ -316,8 +317,9 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72 h1:VqE9gduFZ4dbR7XoL77lHFp0/DyDUBKSXK7CMFkVcV0=

--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/pterm/pterm"
+	"github.com/urfave/cli/v2"
+)
+
+// PerformAllBefore wraps all the specified BeforeFuncs into a single BeforeFunc.
+func PerformAllBefore(actions ...cli.BeforeFunc) cli.BeforeFunc {
+	return func(ctx *cli.Context) error {
+		for i := range actions {
+			action := actions[i]
+			if err := action(ctx); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+// HandleNoColor handles FlagNoColor to disable console coloring.
+func HandleNoColor(ctx *cli.Context) error {
+	noColor := ctx.Bool(FlagNoColor.Name)
+	isTerminal := isatty.IsTerminal(os.Stdout.Fd())
+
+	if noColor || !isTerminal {
+		pterm.DisableColor()
+	}
+
+	return nil
+}

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -14,3 +14,9 @@ var FlagOutputFormat = &cli.StringFlag{
 	Usage:   fmt.Sprintf("Output `format`. Allowed values: %s", strings.Join(AvailableOutputFormatStrings, ", ")),
 	Value:   string(OutputFormatTable),
 }
+
+// FlagNoColor disables coloring in the console output.
+var FlagNoColor = &cli.BoolFlag{
+	Name:  "no-color",
+	Usage: "Disables coloring for the console output. Automatically enabled when the output is not a terminal.",
+}

--- a/internal/cmd/profile/list_command.go
+++ b/internal/cmd/profile/list_command.go
@@ -23,8 +23,10 @@ func listCommand() *cli.Command {
 		Usage: "List all your Spacelift account profiles",
 		Flags: []cli.Flag{
 			cmd.FlagOutputFormat,
+			cmd.FlagNoColor,
 		},
 		ArgsUsage: cmd.EmptyArgsUsage,
+		Before:    cmd.HandleNoColor,
 		Action: func(ctx *cli.Context) error {
 			profiles := manager.GetAll()
 

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -48,9 +48,10 @@ func Command() *cli.Command {
 				Usage: "List the stacks you have access to",
 				Flags: []cli.Flag{
 					cmd.FlagOutputFormat,
+					cmd.FlagNoColor,
 				},
 				Action:    listStacks(),
-				Before:    authenticated.Ensure,
+				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
@@ -153,9 +154,10 @@ func Command() *cli.Command {
 				Flags: []cli.Flag{
 					flagStackID,
 					cmd.FlagOutputFormat,
+					cmd.FlagNoColor,
 				},
 				Action:    (&showStackCommand{}).showStack,
-				Before:    authenticated.Ensure,
+				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{


### PR DESCRIPTION
Added a `--no-color` flag that disables pterm coloring for the following commands that use table output:

- `profile list`
- `stack list`
- `stack show`

The reason I added it to individual commands rather than adding the option to the root command is because of the way the urfave cli library works - that would have caused us to have to write commands like `spacectl --no-color stack list` instead of `spacectl stack list --no-color`.

In addition, if we detect the output is not a terminal, we disable coloring automatically.

Issues: #52

Here's a screenshot showing it working:

![image](https://user-images.githubusercontent.com/1884632/161250952-b1f6fdf8-9775-403a-ad47-87cc7ba4c30b.png)
