### PR TITLE
Add `spacectl stack retry`

### DIFF
--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -31,7 +31,7 @@ func localPreview() cli.ActionFunc {
 
 		var uploadMutation struct {
 			UploadLocalWorkspace struct {
-				ID        string `grapqhl:"id"`
+				ID        string `graphql:"id"`
 				UploadURL string `graphql:"uploadUrl"`
 			} `graphql:"uploadLocalWorkspace(stack: $stack)"`
 		}
@@ -65,7 +65,7 @@ func localPreview() cli.ActionFunc {
 
 		var triggerMutation struct {
 			RunProposeLocalWorkspace struct {
-				ID string `grapqhl:"id"`
+				ID string `graphql:"id"`
 			} `graphql:"runProposeLocalWorkspace(stack: $stack, workspace: $workspace)"`
 		}
 

--- a/internal/cmd/stack/run_confirm.go
+++ b/internal/cmd/stack/run_confirm.go
@@ -16,7 +16,7 @@ func runConfirm() cli.ActionFunc {
 
 		var mutation struct {
 			RunConfirm struct {
-				ID string `grapqhl:"id"`
+				ID string `graphql:"id"`
 			} `graphql:"runConfirm(stack: $stack, run: $run)"`
 		}
 

--- a/internal/cmd/stack/run_retry.go
+++ b/internal/cmd/stack/run_retry.go
@@ -1,0 +1,48 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+)
+
+func runRetry(cliCtx *cli.Context) error {
+	stackID := cliCtx.String(flagStackID.Name)
+	runID := cliCtx.String(flagRun.Name)
+
+	var mutation struct {
+		RunRetry struct {
+			ID string `graphql:"id"`
+		} `graphql:"runRetry(stack: $stack, run: $run)"`
+	}
+
+	variables := map[string]interface{}{
+		"stack": graphql.ID(stackID),
+		"run":   graphql.ID(runID),
+	}
+
+	if err := authenticated.Client.Mutate(cliCtx.Context, &mutation, variables); err != nil {
+		return err
+	}
+
+	fmt.Printf("Run ID %q has been successfully retried\n", runID)
+	fmt.Println("The live run can be visited at", authenticated.Client.URL(
+		"/stack/%s/run/%s",
+		stackID,
+		mutation.RunRetry.ID,
+	))
+
+	if !cliCtx.Bool(flagTail.Name) {
+		return nil
+	}
+
+	terminal, err := runLogs(cliCtx.Context, stackID, mutation.RunRetry.ID)
+	if err != nil {
+		return err
+	}
+
+	return terminal.Error()
+}

--- a/internal/cmd/stack/run_trigger.go
+++ b/internal/cmd/stack/run_trigger.go
@@ -17,7 +17,7 @@ func runTrigger(spaceliftType, humanType string) cli.ActionFunc {
 
 		var mutation struct {
 			RunTrigger struct {
-				ID string `grapqhl:"id"`
+				ID string `graphql:"id"`
 			} `graphql:"runTrigger(stack: $stack, commitSha: $sha, runType: $type)"`
 		}
 

--- a/internal/cmd/stack/set_current_commit.go
+++ b/internal/cmd/stack/set_current_commit.go
@@ -20,7 +20,7 @@ func setCurrentCommit(cliCtx *cli.Context) error {
 			TrackedCommit *struct {
 				Hash    string `graphql:"hash"`
 				Message string `graphql:"message"`
-			} `grapqhl:"trackedCommit"`
+			} `graphql:"trackedCommit"`
 		} `graphql:"stackSetCurrentCommit(id: $stack, sha: $sha)"`
 	}
 

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -44,6 +44,19 @@ func Command() *cli.Command {
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
+				Category: "Run management",
+				Name:     "retry",
+				Usage:    "Retry a failed run",
+				Flags: []cli.Flag{
+					flagStackID,
+					flagRun,
+					flagTail,
+				},
+				Action:    runRetry,
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+			{
 				Name:  "list",
 				Usage: "List the stacks you have access to",
 				Flags: []cli.Flag{

--- a/internal/cmd/stack/task_command.go
+++ b/internal/cmd/stack/task_command.go
@@ -16,7 +16,7 @@ func taskCommand(cliCtx *cli.Context) error {
 
 	var mutation struct {
 		TaskCreate struct {
-			ID string `grapqhl:"id"`
+			ID string `graphql:"id"`
 		} `graphql:"taskCreate(stack: $stack, command: $command, skipInitialization: $noinit)"`
 	}
 


### PR DESCRIPTION
- Added a new retry command. This can be used to retry both proposed and tracked runs.
- Fixed a typo in some of the graphql field tags. It must have worked because the name wasn't being overridden.

Issues: #53