### PR TITLE
Fix spacectl race on terminal state when reading logs

### DIFF
--- a/internal/cmd/stack/run_logs.go
+++ b/internal/cmd/stack/run_logs.go
@@ -17,6 +17,7 @@ func runLogs(ctx context.Context, stack, run string) (terminal *structs.RunState
 
 	go func() {
 		terminal, err = runStates(ctx, stack, run, lines)
+		close(lines)
 	}()
 
 	for line := range lines {
@@ -27,8 +28,6 @@ func runLogs(ctx context.Context, stack, run string) (terminal *structs.RunState
 }
 
 func runStates(ctx context.Context, stack, run string, sink chan<- string) (*structs.RunStateTransition, error) {
-	defer func() { close(sink) }()
-
 	var query struct {
 		Stack *struct {
 			Run *struct {


### PR DESCRIPTION
<img width="587" alt="boom" src="https://user-images.githubusercontent.com/571786/166225621-e266cb2b-4641-40cb-b152-8c0c3f0a6fd5.png">

<img width="1174" alt="The_Go_Programming_Language_Specification_-_The_Go_Programming_Language" src="https://user-images.githubusercontent.com/571786/166225676-e2aaaabf-ecb1-4ca4-ac5e-67673f35441b.png">

[Source](https://go.dev/ref/spec#Defer_statements).