### PR TITLE
BUGFIX - Add missing triggers for lint workflow + fix for fatalf logging of failed compileTime parse

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 
-on: [push]
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
 
 jobs:
   lint:

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"os"
 	"time"
-	"fmt"
 
 	"github.com/urfave/cli/v2"
 
@@ -19,7 +18,7 @@ var date = "2006-01-02T15:04:05Z"
 func main() {
 	compileTime, err := time.Parse(time.RFC3339, date)
 	if err != nil {
-		log.Fatal(fmt.Sprintf("Could not parse compilation date: %v", err))
+		log.Fatalf("Could not parse compilation date: %v", err)
 	}
 	app := &cli.App{
 		Name:     "spacectl",


### PR DESCRIPTION
# What's in this PR
* Add missing pull request trigger for lint workflow [made triggers match the unit test workflow]