### PR TITLE
Disable draft releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ signs:
       - "${artifact}"
 
 release:
-  draft: true
+  draft: false
   extra_files:
     - glob: ./key.*
 


### PR DESCRIPTION
At the moment every time we create a release via goreleaser, it creates a draft GitHub release and publishes to Homebrew. The issue with this is that Homebrew users then see a new version available for install, but the binaries aren't available because the release is a draft.

To avoid this happening for now I'm changing the release process to automatically publish the release. We can then tweak the release notes afterwards if required.

Issues: https://github.com/spacelift-io/spacectl/pull/63