### PR TITLE
Add ability to discard unconfirmed run

### DIFF
--- a/internal/cmd/stack/run_discard.go
+++ b/internal/cmd/stack/run_discard.go
@@ -27,18 +27,13 @@ func runDiscard() cli.ActionFunc {
 
 		ctx := context.Background()
 
-		var requestOpts []graphql.RequestOption
-		if cliCtx.IsSet(flagRunMetadata.Name) {
-			requestOpts = append(requestOpts, graphql.WithHeader(UserProvidedRunMetadataHeader, cliCtx.String(flagRunMetadata.Name)))
-		}
-
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
+		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
 			return err
 		}
 
 		fmt.Println("You have successfully discarded a deployment")
 
-		fmt.Println("The live run can be visited at", authenticated.Client.URL(
+		fmt.Println("The run can be visited at", authenticated.Client.URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunDiscard.ID,

--- a/internal/cmd/stack/run_discard.go
+++ b/internal/cmd/stack/run_discard.go
@@ -1,0 +1,58 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+)
+
+func runDiscard() cli.ActionFunc {
+	return func(cliCtx *cli.Context) error {
+		stackID := cliCtx.String(flagStackID.Name)
+
+		var mutation struct {
+			RunDiscard struct {
+				ID string `graphql:"id"`
+			} `graphql:"runDiscard(stack: $stack, run: $run)"`
+		}
+
+		variables := map[string]interface{}{
+			"stack": graphql.ID(stackID),
+			"run":   graphql.ID(cliCtx.String(flagRun.Name)),
+		}
+
+		ctx := context.Background()
+
+		var requestOpts []graphql.RequestOption
+		if cliCtx.IsSet(flagRunMetadata.Name) {
+			requestOpts = append(requestOpts, graphql.WithHeader(UserProvidedRunMetadataHeader, cliCtx.String(flagRunMetadata.Name)))
+		}
+
+		if err := authenticated.Client.Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
+			return err
+		}
+
+		fmt.Println("You have successfully discarded a deployment")
+
+		fmt.Println("The live run can be visited at", authenticated.Client.URL(
+			"/stack/%s/run/%s",
+			stackID,
+			mutation.RunDiscard.ID,
+		))
+
+		if !cliCtx.Bool(flagTail.Name) {
+			return nil
+		}
+
+		terminal, err := runLogs(ctx, stackID, mutation.RunDiscard.ID)
+		if err != nil {
+			return err
+		}
+
+		return terminal.Error()
+	}
+}

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -36,7 +36,6 @@ func Command() *cli.Command {
 				Flags: []cli.Flag{
 					flagStackID,
 					flagRun,
-					flagRunMetadata,
 					flagTail,
 				},
 				Action:    runDiscard(),

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -31,6 +31,20 @@ func Command() *cli.Command {
 			},
 			{
 				Category: "Run management",
+				Name:     "discard",
+				Usage:    "Discard an unconfirmed tracked run",
+				Flags: []cli.Flag{
+					flagStackID,
+					flagRun,
+					flagRunMetadata,
+					flagTail,
+				},
+				Action:    runDiscard(),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+			{
+				Category: "Run management",
 				Name:     "deploy",
 				Usage:    "Start a deployment (tracked run)",
 				Flags: []cli.Flag{


### PR DESCRIPTION
Added a new `spacectl stack discard` command to discard unconfirmed runs.

Issues: #33