### PR TITLE
Add run list command

### DIFF
--- a/internal/cmd/humanize.go
+++ b/internal/cmd/humanize.go
@@ -43,3 +43,12 @@ func HumanizePolicyType(policyType string) string {
 
 	return policyType
 }
+
+// HumanizeGitHash shortens a Git hash to make it more readable.
+func HumanizeGitHash(hash string) string {
+	if len(hash) > 8 {
+		return hash[0:8]
+	}
+
+	return hash
+}

--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -64,3 +64,9 @@ var flagNoTail = &cli.BoolFlag{
 	Usage: "Indicate whether not to tail the run",
 	Value: false,
 }
+
+var flagMaxResults = &cli.IntFlag{
+	Name:  "max-results",
+	Usage: "The maximum number of items to return",
+	Value: 10,
+}

--- a/internal/cmd/stack/list.go
+++ b/internal/cmd/stack/list.go
@@ -119,14 +119,9 @@ func listStacksTable(ctx context.Context) error {
 
 	tableData := [][]string{{"Name", "Commit", "Author", "State", "Worker Pool", "Locked By"}}
 	for _, stack := range query.Stacks {
-		var shortenedHash string
-		if len(stack.TrackedCommit.Hash) > 8 {
-			shortenedHash = stack.TrackedCommit.Hash[0:8]
-		}
-
 		tableData = append(tableData, []string{
 			stack.Name,
-			shortenedHash,
+			cmd.HumanizeGitHash(stack.TrackedCommit.Hash),
 			stack.TrackedCommit.AuthorName,
 			stack.State,
 			stack.WorkerPool.Name,

--- a/internal/cmd/stack/run_list.go
+++ b/internal/cmd/stack/run_list.go
@@ -1,0 +1,186 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd"
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+)
+
+func runList(cliCtx *cli.Context) error {
+	outputFormat, err := cmd.GetOutputFormat(cliCtx)
+	if err != nil {
+		return err
+	}
+
+	stackID := cliCtx.String(flagStackID.Name)
+	maxResults := cliCtx.Int(flagMaxResults.Name)
+
+	switch outputFormat {
+	case cmd.OutputFormatTable:
+		return listRunsTable(cliCtx.Context, stackID, maxResults)
+	case cmd.OutputFormatJSON:
+		return listRunsJSON(cliCtx.Context, stackID, maxResults)
+	}
+
+	return fmt.Errorf("unknown output format: %v", outputFormat)
+}
+
+type runsJSONQuery struct {
+	ID       string `graphql:"id" json:"id"`
+	Branch   string `graphql:"branch" json:"branch"`
+	CanRetry bool   `graphql:"canRetry" json:"canRetry"`
+	Comments []struct {
+		Body      string `graphql:"body" json:"body"`
+		CreatedAt int    `graphql:"createdAt" json:"createdAt"`
+		Username  string `graphql:"username" json:"username"`
+	} `graphql:"comments" json:"comments"`
+	Commit struct {
+		AuthorLogin string `graphql:"authorLogin" json:"authorLogin"`
+		AuthorName  string `graphql:"authorName" json:"authorName"`
+		Hash        string `graphql:"hash" json:"hash"`
+	} `graphql:"commit" json:"commit"`
+	CreatedAt int `graphql:"createdAt" json:"createdAt"`
+	Delta     *struct {
+		AddCount    int `graphql:"addCount" json:"addCount"`
+		ChangeCount int `graphql:"changeCount" json:"changeCount"`
+		DeleteCount int `graphql:"deleteCount" json:"deleteCount"`
+		Resources   int `graphql:"resources" json:"resources"`
+	} `graphql:"delta" json:"delta"`
+	DriftDetection bool   `graphql:"driftDetection" json:"driftDetection"`
+	Expired        bool   `graphql:"expired" json:"expired"`
+	IsMostRecent   bool   `graphql:"isMostRecent" json:"isMostRecent"`
+	NeedsApproval  bool   `graphql:"needsApproval" json:"needsApproval"`
+	State          string `graphql:"state" json:"state"`
+	Title          string `graphql:"title" json:"title"`
+	TriggeredBy    string `graphql:"triggeredBy" json:"triggeredBy"`
+}
+
+func listRunsJSON(ctx context.Context, stackID string, maxResults int) error {
+	var results []runsJSONQuery
+	var before *string
+
+	for len(results) < maxResults {
+		var query struct {
+			Stack *struct {
+				Runs []runsJSONQuery `graphql:"runs(before: $before)"`
+			} `graphql:"stack(id: $stackId)"`
+		}
+
+		if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
+			return errors.Wrap(err, "failed to query run list")
+		}
+
+		if query.Stack == nil {
+			return fmt.Errorf("stack %q not found", stackID)
+		}
+
+		if len(query.Stack.Runs) == 0 {
+			break
+		}
+
+		resultsToAdd := maxResults - len(results)
+		if resultsToAdd > len(query.Stack.Runs) {
+			resultsToAdd = len(query.Stack.Runs)
+		}
+
+		results = append(results, query.Stack.Runs[:resultsToAdd]...)
+
+		before = &query.Stack.Runs[len(query.Stack.Runs)-1].ID
+	}
+
+	return cmd.OutputJSON(results)
+}
+
+type runsTableQuery struct {
+	ID     string `graphql:"id"`
+	State  string `graphql:"state"`
+	Title  string `graphql:"title"`
+	Commit struct {
+		AuthorName string `graphql:"authorName"`
+		Hash       string `graphql:"hash"`
+	} `graphql:"commit"`
+	CreatedAt   int    `graphql:"createdAt"`
+	TriggeredBy string `graphql:"triggeredBy"`
+	Delta       struct {
+		AddCount    int `graphql:"addCount"`
+		ChangeCount int `graphql:"changeCount"`
+		DeleteCount int `graphql:"deleteCount"`
+	} `graphql:"delta"`
+}
+
+func listRunsTable(ctx context.Context, stackID string, maxResults int) error {
+	var results []runsTableQuery
+	var before *string
+
+	for len(results) < maxResults {
+		var query struct {
+			Stack *struct {
+				Runs []runsTableQuery `graphql:"runs(before: $before)"`
+			} `graphql:"stack(id: $stackId)"`
+		}
+
+		if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
+			return errors.Wrap(err, "failed to query run list")
+		}
+
+		if query.Stack == nil {
+			return fmt.Errorf("stack %q not found", stackID)
+		}
+
+		if len(query.Stack.Runs) == 0 {
+			break
+		}
+
+		resultsToAdd := maxResults - len(results)
+		if resultsToAdd > len(query.Stack.Runs) {
+			resultsToAdd = len(query.Stack.Runs)
+		}
+
+		results = append(results, query.Stack.Runs[:resultsToAdd]...)
+
+		before = &query.Stack.Runs[len(query.Stack.Runs)-1].ID
+	}
+
+	tableData := [][]string{{"ID", "Status", "Message", "Commit", "Triggered At", "Triggered By", "Changes"}}
+	for _, run := range results {
+		var deltaComponents []string
+
+		if run.Delta.AddCount > 0 {
+			deltaComponents = append(deltaComponents, fmt.Sprintf("+%d", run.Delta.AddCount))
+		}
+		if run.Delta.ChangeCount > 0 {
+			deltaComponents = append(deltaComponents, fmt.Sprintf("~%d", run.Delta.ChangeCount))
+		}
+		if run.Delta.DeleteCount > 0 {
+			deltaComponents = append(deltaComponents, fmt.Sprintf("-%d", run.Delta.DeleteCount))
+		}
+
+		delta := strings.Join(deltaComponents, " ")
+
+		triggeredBy := run.TriggeredBy
+		if triggeredBy == "" {
+			triggeredBy = "Git commit"
+		}
+
+		createdAt := time.Unix(int64(run.CreatedAt), 0)
+
+		tableData = append(tableData, []string{
+			run.ID,
+			run.State,
+			run.Title,
+			cmd.HumanizeGitHash(run.Commit.Hash),
+			createdAt.Format(time.RFC3339),
+			triggeredBy,
+			delta,
+		})
+	}
+
+	return cmd.OutputTable(tableData, true)
+}

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -125,6 +125,24 @@ func Command() *cli.Command {
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
+				Name:  "run",
+				Usage: "Manage a stack's runs",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "list",
+						Usage: "Lists the runs for a specified stack",
+						Flags: []cli.Flag{
+							flagStackID,
+							flagMaxResults,
+							cmd.FlagOutputFormat,
+						},
+						Action:    runList,
+						Before:    authenticated.Ensure,
+						ArgsUsage: cmd.EmptyArgsUsage,
+					},
+				},
+			},
+			{
 				Category: "Stack management",
 				Name:     "set-current-commit",
 				Usage:    "Set current commit on the stack",
@@ -138,7 +156,7 @@ func Command() *cli.Command {
 			},
 			{
 				Name:  "environment",
-				Usage: "Manage Stack`s environment`",
+				Usage: "Manage a stack's environment",
 				Subcommands: []*cli.Command{
 					{
 						Name:  "setvar",

--- a/specs/spacectl-to-v1.md
+++ b/specs/spacectl-to-v1.md
@@ -179,7 +179,7 @@ We should support the following commands for working with Stacks:
 Subcommands:
 
 - `spacectl stack run`
-  - [ ] `list` - lists the runs for your stack
+  - [x] `list` - lists the runs for your stack
   - [ ] `logs` - shows the logs for a run
   - [ ] `show` - outputs information about a specified Run
 - `spacectl stack task`


### PR DESCRIPTION
Added a new command to list the runs for a stack.

I've tried to keep the amount of data in the table output minimal while still being useful, but we'll probably need to tweak it in future. The JSON output only contains fields that are relevant for a tracked run.

Here's what the table output looks like:

![image](https://user-images.githubusercontent.com/1884632/186465967-9025773e-88dc-415c-9c3a-46db07386890.png)

Here's a sample of the JSON output:

```json
[
  {
    "id": "01GB88NGH5D5JRS51ZJSMZ42N9",
    "branch": "pr-promotion-branch",
    "canRetry": true,
    "comments": [
      {
        "body": "This was the best result",
        "createdAt": 1661356291,
        "username": "adamconnelly"
      }
    ],
    "commit": {
      "authorLogin": "adamconnelly",
      "authorName": "Adam Connelly",
      "hash": "50da536a8698873c3cc11647ab6d9b21585be68e"
    },
    "createdAt": 1661356130,
    "delta": null,
    "driftDetection": false,
    "expired": false,
    "isMostRecent": true,
    "needsApproval": true,
    "state": "FAILED",
    "title": "Reduce password length",
    "triggeredBy": "adamconnelly"
  },
]
```

Issues: #75