### PR TITLE
Rename lock note flag

### DIFF
--- a/internal/cmd/stack/lock.go
+++ b/internal/cmd/stack/lock.go
@@ -20,7 +20,7 @@ type stackUnlockMutation struct {
 }
 
 var flagStackLockNote = &cli.StringFlag{
-	Name:     "name",
+	Name:     "note",
 	Usage:    "Description of why the lock was acquired.",
 	Required: false,
 }

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -242,8 +242,9 @@ func Command() *cli.Command {
 				ArgsUsage: "COMMAND",
 			},
 			{
-				Name:  "lock",
-				Usage: "Locks a stack for exclusive use.",
+				Category: "Stack management",
+				Name:     "lock",
+				Usage:    "Locks a stack for exclusive use.",
 				Flags: []cli.Flag{
 					flagStackID,
 					flagStackLockNote,
@@ -253,8 +254,9 @@ func Command() *cli.Command {
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
-				Name:  "unlock",
-				Usage: "Unlocks a stack.",
+				Category: "Stack management",
+				Name:     "unlock",
+				Usage:    "Unlocks a stack.",
 				Flags: []cli.Flag{
 					flagStackID,
 				},


### PR DESCRIPTION
I've renamed the flag from `--name` to `--note` so it makes a bit more sense, and moved the commands into the "Stack management" category.