### PR TITLE
Keep env variable consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ steps:
 
   - name: Deploy infrastructure
     env:
-      SPACELIFT_API_ENDPOINT: https://mycorp.app.spacelift.io
+      SPACELIFT_API_KEY_ENDPOINT: https://mycorp.app.spacelift.io
       SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
       SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_API_KEY_SECRET }}
     run: spacectl stack deploy --id my-infra-stack
@@ -144,14 +144,14 @@ NOTE: API tokens are generally short-lived and will need to be re-created often.
 
 GitHub tokens are only available to accounts that use GitHub as their identity provider, but are very convenient for use in GitHub actions. To use a GitHub token, set the following environment variables:
 
-- `SPACELIFT_API_ENDPOINT` - the URL to your Spacelift account, for example `https://mycorp.app.spacelift.io`.
+- `SPACELIFT_API_KEY_ENDPOINT` - the URL to your Spacelift account, for example `https://mycorp.app.spacelift.io`.
 - `SPACELIFT_API_GITHUB_TOKEN` - a GitHub personal access token.
 
 #### Spacelift API keys
 
 To use a Spacelift API key, set the following environment variables:
 
-- `SPACELIFT_API_ENDPOINT` - the URL to your Spacelift account, for example `https://mycorp.app.spacelift.io`.
+- `SPACELIFT_API_KEY_ENDPOINT` - the URL to your Spacelift account, for example `https://mycorp.app.spacelift.io`.
 - `SPACELIFT_API_KEY_ID` - the ID of your Spacelift API key. Available via the Spacelift application.
 - `SPACELIFT_API_KEY_SECRET` - the secret for your API key. Only available when the secret is created.
 

--- a/client/session/from_environment.go
+++ b/client/session/from_environment.go
@@ -10,7 +10,13 @@ import (
 const (
 	// EnvSpaceliftAPIEndpoint represents the name of the environment variable
 	// pointing to the Spacelift API endpoint.
+	//
+	// Deprecated
 	EnvSpaceliftAPIEndpoint = "SPACELIFT_API_ENDPOINT"
+
+	// EnvSpaceliftAPIKeyEndpoint represents the name of the environment variable
+	// pointing to the Spacelift API endpoint.
+	EnvSpaceliftAPIKeyEndpoint = "SPACELIFT_API_KEY_ENDPOINT"
 
 	// EnvSpaceliftAPIKeyID represents the name of the environment variable
 	// pointing to the Spacelift API key ID.
@@ -40,9 +46,14 @@ func FromEnvironment(ctx context.Context, client *http.Client) func(func(string)
 			return FromAPIToken(ctx, client)(token)
 		}
 
-		endpoint, ok := lookup(EnvSpaceliftAPIEndpoint)
+		endpoint, ok := lookup(EnvSpaceliftAPIKeyEndpoint)
 		if !ok {
-			return nil, fmt.Errorf("%s missing from the environment", EnvSpaceliftAPIEndpoint)
+			// Keep backwards compatibility with older version of spacectl.
+			endpoint, ok = lookup(EnvSpaceliftAPIEndpoint)
+			if !ok {
+				return nil, fmt.Errorf("%s missing from the environment", EnvSpaceliftAPIKeyEndpoint)
+			}
+			fmt.Printf("Environment variable %q is deprecated, please use %q\n", EnvSpaceliftAPIEndpoint, EnvSpaceliftAPIKeyEndpoint)
 		}
 
 		if gitHubToken, ok := lookup(EnvSpaceliftAPIGitHubToken); ok {


### PR DESCRIPTION
Terraform provider uses `SPACELIFT_API_KEY_ENDPOINT` while this used `SPACELIFT_API_ENDPOINT` to set the same value in the env. Now both tools use `SPACELIFT_API_KEY_ENDPOINT`.

For now we still fallback to `SPACELIFT_API_ENDPOINT` if the new value is not set.