### PR TITLE
Add trailing newline for set-current-commit output

### DIFF
--- a/internal/cmd/stack/set_current_commit.go
+++ b/internal/cmd/stack/set_current_commit.go
@@ -40,7 +40,7 @@ func setCurrentCommit(cliCtx *cli.Context) error {
 		return errors.New("no tracked commit set on the Stack")
 	}
 
-	_, err := fmt.Fprintf(os.Stdout, "Current commit set to %q: (SHA %s)", commit.Message, commit.Hash)
+	_, err := fmt.Printf("Current commit set to %q: (SHA %s)\n", commit.Message, commit.Hash)
 
 	return err
 }

--- a/internal/cmd/stack/set_current_commit.go
+++ b/internal/cmd/stack/set_current_commit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli/v2"


### PR DESCRIPTION
When updating multiple stacks, the current print format ends up as:
```
Current commit set to "$MESSAGE": (SHA $HASH)Current commit set to "$MESSAGE": (SHA $HASH)Current commit set to "$MESSAGE": (SHA $HASH)
```

Versus after this fix:
```
Current commit set to "$MESSAGE": (SHA $HASH)
Current commit set to "$MESSAGE": (SHA $HASH)
Current commit set to "$MESSAGE": (SHA $HASH)
```

This also removes the sole use of `fmt.Fprintf` in the codebase.