### PR TITLE
Update archiver library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/mholt/archiver/v3 => github.com/spacelift-io/archiver/v3 v3.3.1-0.20210524114144-7c0457f07819
+replace github.com/mholt/archiver/v3 => github.com/spacelift-io/archiver/v3 v3.3.1-0.20221117135619-d7d90ab08987
 
 replace github.com/shurcooL/graphql => github.com/marcinwyszynski/graphql v0.0.0-20210505073322-ed22d920d37d

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/spacelift-io/archiver/v3 v3.3.1-0.20210524114144-7c0457f07819 h1:KPyKFpnC7vuvZ7QSUy66GeVBR1W03JDFExgPuhIAWj0=
-github.com/spacelift-io/archiver/v3 v3.3.1-0.20210524114144-7c0457f07819/go.mod h1:YnQtqsp+94Rwd0D/rk5cnLrxusUBUXg+08Ebtr1Mqao=
+github.com/spacelift-io/archiver/v3 v3.3.1-0.20221117135619-d7d90ab08987 h1:L8buChChTRSHaGHco2ptAFivZUDYHhr7+OG5haf5FJI=
+github.com/spacelift-io/archiver/v3 v3.3.1-0.20221117135619-d7d90ab08987/go.mod h1:YnQtqsp+94Rwd0D/rk5cnLrxusUBUXg+08Ebtr1Mqao=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -52,6 +52,7 @@ func localPreview() cli.ActionFunc {
 		}
 
 		tgz := *archiver.DefaultTarGz
+		tgz.ForceArchiveImplicitTopLevelFolder = true
 		tgz.MatchFn = matchFn
 
 		if err := tgz.Archive([]string{"."}, fp); err != nil {


### PR DESCRIPTION
run with single subdir doesn't loose track anymore:
```
Uploading local workspace...
338 B / 338 B [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s 200ms
You have successfully created a local preview run!
The live run can be visited at http://spc.app.spacelift.tf/stack/testing-dirs/run/00002Z768YDT46QQBEYA3GQZV6

-----------------
QUEUED	Thu Nov 17 16:17:25 EET 2022
-----------------


-----------------
PREPARING	Thu Nov 17 16:17:28 EET 2022
-----------------

[Ground Control] This is Ground Control to public worker 000000000000, commencing countdown
[Ground Control] No initialization policies attached
[Ground Control] Creating metadata...
[Ground Control] Uploading metadata...
[Ground Control] Metadata is GO
[Ground Control] Creating workspace...
[Ground Control] Encrypting workspace...
[Ground Control] Uploading workspace...
[Ground Control] Workspace is GO
[Ground Control] We're ready 000000000000
[Ground Control] Over to you 000000000000, we'll see you on the other side
[000000000000] Verifying container image prerequisites...
[000000000000] Successfully verified container image prerequisites

-----------------
INITIALIZING	Thu Nov 17 16:17:35 EET 2022
-----------------

[000000000000] Using binary "terraform" from /bin/terraform
[000000000000] Configuring Terraform CLI...
[000000000000] Terraform CLI config is GO
[000000000000] Initializing workspace with 0 custom hooks...

```