### PR TITLE
Provide a no upload flag for easier local preview debugging

### DIFF
--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -75,3 +75,9 @@ var flagMaxResults = &cli.IntFlag{
 	Usage: "The maximum number of items to return",
 	Value: 10,
 }
+
+var flagNoUpload = &cli.BoolFlag{
+	Name:  "no-upload",
+	Usage: "Indicate whether Spacectl should prepare the workspace archive, but skip uploading it. Useful for debugging ignorefiles.",
+	Value: false,
+}

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -27,7 +27,7 @@ func localPreview() cli.ActionFunc {
 			}
 		}
 
-		fmt.Println("Uploading local workspace...")
+		fmt.Println("Packing local workspace...")
 
 		var uploadMutation struct {
 			UploadLocalWorkspace struct {
@@ -58,7 +58,15 @@ func localPreview() cli.ActionFunc {
 		if err := tgz.Archive([]string{"."}, fp); err != nil {
 			return fmt.Errorf("couldn't archive local directory: %w", err)
 		}
+
+		if cliCtx.Bool(flagNoUpload.Name) {
+			fmt.Println("No upload flag was provided, will not create run, saved archive at:", fp)
+			return nil
+		}
+
 		defer os.Remove(fp)
+
+		fmt.Println("Uploading local workspace...")
 
 		if err := uploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp); err != nil {
 			return fmt.Errorf("couldn't upload archive: %w", err)

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -115,6 +115,7 @@ func Command() *cli.Command {
 					flagNoFindRepositoryRoot,
 					flagRunMetadata,
 					flagNoTail,
+					flagNoUpload,
 				},
 				Action:    localPreview(),
 				Before:    authenticated.Ensure,


### PR DESCRIPTION
```
➜ stack local-preview --id testing-dirs --no-upload
Packing local workspace...
No upload flag was provided, will not create run, saved archive at: /tmp/spacectl/local-workspace/01GJMETBEM81ZJ1TFP32000000.tar.gz
```