### PR TITLE
login: web-based login should bind to localhost

### DIFF
--- a/internal/cmd/profile/login_command.go
+++ b/internal/cmd/profile/login_command.go
@@ -226,7 +226,7 @@ func loginUsingWebBrowser(creds *session.StoredCredentials) error {
 	}
 
 	m := http.NewServeMux()
-	server := &http.Server{Addr: fmt.Sprintf(":%d", cliServerPort), Handler: m, ReadHeaderTimeout: 5 * time.Second}
+	server := &http.Server{Addr: fmt.Sprintf("localhost:%d", cliServerPort), Handler: m, ReadHeaderTimeout: 5 * time.Second}
 	m.HandleFunc("/", handler)
 
 	fmt.Printf("\nOpening browser to %s\n\n", browserURL)


### PR DESCRIPTION
This shortcuts the macos warning and confirmation to open network connections.

The origin of these requests should only ever come from localhost.