### PR TITLE
Rename create-gpg-key to add-gpg-key

### DIFF
--- a/internal/cmd/provider/add_gpg_key.go
+++ b/internal/cmd/provider/add_gpg_key.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
 )
 
-func createGPGKey() cli.ActionFunc {
+func addGPGKey() cli.ActionFunc {
 	return func(cliCtx *cli.Context) error {
 		keyGenerate := cliCtx.Bool(flagKeyGenerate.Name)
 		keyImport := cliCtx.Bool(flagKeyImport.Name)

--- a/internal/cmd/provider/provider.go
+++ b/internal/cmd/provider/provider.go
@@ -15,8 +15,8 @@ func Command() *cli.Command {
 		Subcommands: []*cli.Command{
 			{
 				Category: "GPG key management",
-				Name:     "create-gpg-key",
-				Usage:    "Create a new GPG key for signing provider releases",
+				Name:     "add-gpg-key",
+				Usage:    "Adds a new GPG key for signing provider releases",
 				Flags: []cli.Flag{
 					flagKeyEmail,
 					flagKeyGenerate,
@@ -24,7 +24,7 @@ func Command() *cli.Command {
 					flagKeyName,
 					flagKeyPath,
 				},
-				Action:    createGPGKey(),
+				Action:    addGPGKey(),
 				Before:    authenticated.Ensure,
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},


### PR DESCRIPTION
As per @jmfontaine 's [suggestion](https://github.com/spacelift-io/user-documentation/pull/115#discussion_r1065208317), `create-gpg-key` sounds weird for an operation that can also import an existing key.