### PR TITLE
Provide whoami command

### DIFF
--- a/client/session/from_current_profile.go
+++ b/client/session/from_current_profile.go
@@ -5,20 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
-	"path/filepath"
 )
 
 // FromCurrentProfile creates a session from credentials stored in the currently selected profile.
 func FromCurrentProfile(ctx context.Context, client *http.Client) (Session, error) {
-	userHomeDir, err := os.UserHomeDir()
+	manager, err := UserProfileManager()
 	if err != nil {
-		return nil, fmt.Errorf("could not find user home directory: %w", err)
-	}
-
-	manager, err := NewProfileManager(filepath.Join(userHomeDir, SpaceliftConfigDirectory))
-	if err != nil {
-		return nil, fmt.Errorf("could not create profile manager: %w", err)
+		return nil, fmt.Errorf("could not access profile manager: %w", err)
 	}
 
 	currentProfile := manager.Current()

--- a/client/session/profile_manager.go
+++ b/client/session/profile_manager.go
@@ -48,6 +48,19 @@ type ProfileManager struct {
 	Configuration *configuration
 }
 
+// UserProfileManager creates a new ProfileManager using the user home directory to store the profile data.
+func UserProfileManager() (*ProfileManager, error) {
+	userHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("could not find user home directory: %w", err)
+	}
+	manager, err := NewProfileManager(filepath.Join(userHomeDir, SpaceliftConfigDirectory))
+	if err != nil {
+		return nil, fmt.Errorf("could not create profile manager: %w", err)
+	}
+	return manager, nil
+}
+
 // NewProfileManager creates a new ProfileManager using the specified directory to store the profile data.
 func NewProfileManager(profilesDirectory string) (*ProfileManager, error) {
 	if err := os.MkdirAll(profilesDirectory, 0700); err != nil {

--- a/internal/cmd/profile/get_alias_with_profile.go
+++ b/internal/cmd/profile/get_alias_with_profile.go
@@ -3,8 +3,6 @@ package profile
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/urfave/cli/v2"
@@ -19,14 +17,9 @@ func getAliasWithAPITokenProfile(cliCtx *cli.Context) error {
 		return nil
 	}
 
-	userHomeDir, err := os.UserHomeDir()
+	manager, err := session.UserProfileManager()
 	if err != nil {
-		return fmt.Errorf("could not find user home directory: %w", err)
-	}
-
-	manager, err := session.NewProfileManager(filepath.Join(userHomeDir, session.SpaceliftConfigDirectory))
-	if err != nil {
-		return fmt.Errorf("could not create profile manager: %w", err)
+		return fmt.Errorf("could not accesss profile manager: %w", err)
 	}
 
 	profile := manager.Current()

--- a/internal/cmd/profile/profile.go
+++ b/internal/cmd/profile/profile.go
@@ -2,8 +2,6 @@ package profile
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/urfave/cli/v2"
 
@@ -20,16 +18,10 @@ func Command() *cli.Command {
 		Name:  "profile",
 		Usage: "Manage Spacelift profiles",
 		Before: func(cliCtx *cli.Context) error {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("could not get user home directory: %w", err)
-			}
-
-			configDir := filepath.Join(homeDir, session.SpaceliftConfigDirectory)
-			if manager, err = session.NewProfileManager(configDir); err != nil {
+			var err error
+			if manager, err = session.UserProfileManager(); err != nil {
 				return fmt.Errorf("could not initialize profile manager: %w", err)
 			}
-
 			return nil
 		},
 		Subcommands: []*cli.Command{

--- a/internal/cmd/whoami/whoami.go
+++ b/internal/cmd/whoami/whoami.go
@@ -1,0 +1,55 @@
+package whoami
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/client/session"
+	"github.com/spacelift-io/spacectl/internal/cmd"
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+)
+
+// Command returns the logged-in user's information.
+func Command() *cli.Command {
+	return &cli.Command{
+		Name:  "whoami",
+		Usage: "Print out logged-in user's information",
+		Action: func(cliCtx *cli.Context) error {
+			manager, err := session.UserProfileManager()
+			if err != nil {
+				return fmt.Errorf("could not access profile manager: %w", err)
+			}
+			var endpoint string
+			if p := manager.Current(); p != nil {
+				endpoint = p.Credentials.Endpoint
+			}
+
+			var query struct {
+				Viewer struct {
+					ID   string `graphql:"id" json:"id"`
+					Name string `graphql:"name" json:"name"`
+				}
+			}
+			if err := authenticated.Client.Query(cliCtx.Context, &query, map[string]interface{}{}); err != nil {
+				return err
+			}
+
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "    ")
+			return encoder.Encode(struct {
+				ID       string `json:"id,omitempty"`
+				Name     string `json:"name,omitempty"`
+				Endpoint string `json:"endpoint,omitempty"`
+			}{
+				ID:       query.Viewer.ID,
+				Name:     query.Viewer.Name,
+				Endpoint: endpoint,
+			})
+		},
+		Before:    authenticated.Ensure,
+		ArgsUsage: cmd.EmptyArgsUsage,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/provider"
 	"github.com/spacelift-io/spacectl/internal/cmd/stack"
 	versioncmd "github.com/spacelift-io/spacectl/internal/cmd/version"
+	"github.com/spacelift-io/spacectl/internal/cmd/whoami"
 	"github.com/spacelift-io/spacectl/internal/cmd/workerpools"
 )
 
@@ -33,6 +34,7 @@ func main() {
 			profile.Command(),
 			provider.Command(),
 			stack.Command(),
+			whoami.Command(),
 			versioncmd.Command(version),
 			workerpools.Command(),
 		},


### PR DESCRIPTION
whoami command prints out logged-in user's information as JSON, similarly to `aws sts get-caller-identity`.

```
$ spacectl whoami
{
    "id": "...",
    "name": "...",
    "endpoint": "..."
}
```