### PR TITLE
Add a command to open a stack in your browser

### DIFF
--- a/client/structs/search.go
+++ b/client/structs/search.go
@@ -1,0 +1,34 @@
+package structs
+
+import "github.com/shurcooL/graphql"
+
+// SearchInput is the main object provided to any search query.
+type SearchInput struct {
+	First          *graphql.Int      `json:"first"`
+	After          *graphql.String   `json:"after"`
+	FullTextSearch *graphql.String   `json:"fullTextSearch"`
+	Predicates     *[]QueryPredicate `json:"predicates"`
+}
+
+// QueryPredicate Field and Constraint pair
+// for search input.
+type QueryPredicate struct {
+	Field      graphql.String       `json:"field"`
+	Constraint QueryFieldConstraint `json:"constraint"`
+}
+
+// QueryFieldConstraint is a constraint used
+// in a search query.
+type QueryFieldConstraint struct {
+	BooleanEquals *[]graphql.Boolean `json:"booleanEquals"`
+	EnumEquals    *[]graphql.String  `json:"enumEquals"`
+	StringMatches *[]graphql.String  `json:"stringMatches"`
+}
+
+// PageInfo is the extra information about
+// a searched page.
+type PageInfo struct {
+	EndCursor       string `json:"endCursor"`
+	HasNextPage     bool   `json:"hasNextPage"`
+	HasPreviousPage bool   `json:"hasPreviousPage"`
+}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/ProtonMail/go-mime v0.0.0-20221031134845-8fd9bc37cf08 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/containerd/console v1.0.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
@@ -40,6 +41,7 @@ require (
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/lithammer/fuzzysearch v1.1.5 // indirect
+	github.com/manifoldco/promptui v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,10 @@ github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkU
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cheggaaa/pb/v3 v3.1.0 h1:3uouEsl32RL7gTiQsuaXD4Bzbfl5tGztXGUvXbs4O04=
 github.com/cheggaaa/pb/v3 v3.1.0/go.mod h1:YjrevcBqadFDaGQKRdmZxTY42pXEqda48Ea3lt0K/BE=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cloudflare/circl v1.1.0 h1:bZgT/A+cikZnKIwn7xL2OBj012Bmvho/o6RpRvv3GKY=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
@@ -89,6 +93,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lithammer/fuzzysearch v1.1.5 h1:Ag7aKU08wp0R9QCfF4GoGST9HbmAIeLP7xwMrOBEp1c=
 github.com/lithammer/fuzzysearch v1.1.5/go.mod h1:1R1LRNk7yKid1BaQkmuLQaHruxcC4HmAH30Dh61Ih1Q=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/marcinwyszynski/graphql v0.0.0-20210505073322-ed22d920d37d h1:9Z8P/yiZQQucF5Yo3bmn0JD7Y4TrtGETsbmZpexIuxc=
 github.com/marcinwyszynski/graphql v0.0.0-20210505073322-ed22d920d37d/go.mod h1:arY+KAJGvLcmVrvOSx+bDyXcfKl4+eurb19qg+FYX08=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -177,6 +183,7 @@ golang.org/x/net v0.0.0-20220909164309-bea034e7d591 h1:D0B/7al0LLrVC8aWF4+oxpv/m
 golang.org/x/net v0.0.0-20220909164309-bea034e7d591/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 h1:lxqLZaMad/dJHMFZH0NiNpiEZI/nhgWhe4wgzpE+MuA=
 golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/browser.go
+++ b/internal/browser.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// OpenWebBrowser will try to open the default browser
+// on a the callers machine. It supports windows, darwin and windows.
+func OpenWebBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		r := strings.NewReplacer("&", "^&")
+		cmd = exec.Command("cmd", "/c", "start", r.Replace(url)) //#nosec
+	default:
+		return errors.New("unsupported platform")
+	}
+
+	err := cmd.Start()
+	if err != nil {
+		return errors.Wrap(err, "could not open the browser")
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		return errors.Wrap(err, "could not wait for the opening browser")
+	}
+
+	return nil
+}

--- a/internal/cmd/profile/login_command.go
+++ b/internal/cmd/profile/login_command.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -233,7 +231,7 @@ func loginUsingWebBrowser(creds *session.StoredCredentials) error {
 
 	fmt.Printf("\nOpening browser to %s\n\n", browserURL)
 
-	if err := openWebBrowser(browserURL); err != nil {
+	if err := internal.OpenWebBrowser(browserURL); err != nil {
 		server.Close()
 		return err
 	}
@@ -266,33 +264,6 @@ func buildBrowserURL(endpoint, pubKey string, port int) (string, error) {
 	base.RawQuery = q.Encode()
 
 	return base.String(), nil
-}
-
-func openWebBrowser(url string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "linux":
-		cmd = exec.Command("xdg-open", url)
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "windows":
-		r := strings.NewReplacer("&", "^&")
-		cmd = exec.Command("cmd", "/c", "start", r.Replace(url)) //#nosec
-	default:
-		return errors.New("unsupported platform")
-	}
-
-	err := cmd.Start()
-	if err != nil {
-		return errors.Wrap(err, "could not open the browser")
-	}
-
-	err = cmd.Wait()
-	if err != nil {
-		return errors.Wrap(err, "could not wait for the opening browser")
-	}
-
-	return nil
 }
 
 func persistAccessCredentials(creds *session.StoredCredentials) error {

--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -81,3 +81,21 @@ var flagNoUpload = &cli.BoolFlag{
 	Usage: "Indicate whether Spacectl should prepare the workspace archive, but skip uploading it. Useful for debugging ignorefiles.",
 	Value: false,
 }
+
+var flagIgnoreSubdir = &cli.BoolFlag{
+	Name:  "ignore-subdir",
+	Usage: "[Optional] Indicate whetever open command should ignore the current subdir and only use the repository to search for a stack",
+	Value: false,
+}
+
+var flagCurrentBranch = &cli.BoolFlag{
+	Name:  "current-branch",
+	Usage: "[Optional] Indicate whetever to search a stack by the current branch you're on",
+	Value: false,
+}
+
+var flagSearchCount = &cli.IntFlag{
+	Name:  "count",
+	Usage: "[Optional] Indicate the maximum count of elements returned when searching stacks",
+	Value: 30,
+}

--- a/internal/cmd/stack/list.go
+++ b/internal/cmd/stack/list.go
@@ -33,58 +33,7 @@ func listStacks() cli.ActionFunc {
 
 func listStacksJSON(ctx context.Context) error {
 	var query struct {
-		Stacks []struct {
-			ID             string `graphql:"id" json:"id,omitempty"`
-			Administrative bool   `graphql:"administrative" json:"administrative,omitempty"`
-			Autodeploy     bool   `graphql:"autodeploy" json:"autodeploy,omitempty"`
-			Autoretry      bool   `graphql:"autoretry" json:"autoretry,omitempty"`
-			Blocker        struct {
-				ID string `graphql:"id" json:"id,omitempty"`
-			} `graphql:"blocker"`
-			AfterApply          []string `graphql:"afterApply" json:"afterApply,omitempty"`
-			BeforeApply         []string `graphql:"beforeApply" json:"beforeApply,omitempty"`
-			AfterInit           []string `graphql:"afterInit" json:"afterInit,omitempty"`
-			BeforeInit          []string `graphql:"beforeInit" json:"beforeInit,omitempty"`
-			AfterPlan           []string `graphql:"afterPlan" json:"afterPlan,omitempty"`
-			BeforePlan          []string `graphql:"beforePlan" json:"beforePlan,omitempty"`
-			AfterPerform        []string `graphql:"afterPerform" json:"afterPerform,omitempty"`
-			BeforePerform       []string `graphql:"beforePerform" json:"beforePerform,omitempty"`
-			AfterDestroy        []string `graphql:"afterDestroy" json:"afterDestroy,omitempty"`
-			BeforeDestroy       []string `graphql:"beforeDestroy" json:"beforeDestroy,omitempty"`
-			Branch              string   `graphql:"branch" json:"branch,omitempty"`
-			CanWrite            bool     `graphql:"canWrite" json:"canWrite,omitempty"`
-			CreatedAt           int64    `graphql:"createdAt" json:"createdAt,omitempty"`
-			Deleted             bool     `graphql:"deleted" json:"deleted,omitempty"`
-			Deleting            bool     `graphql:"deleting" json:"deleting,omitempty"`
-			Description         string   `graphql:"description" json:"description,omitempty"`
-			Labels              []string `graphql:"labels" json:"labels,omitempty"`
-			LocalPreviewEnabled bool     `graphql:"localPreviewEnabled" json:"localPreviewEnabled,omitempty"`
-			LockedBy            string   `graphql:"lockedBy" json:"lockedBy,omitempty"`
-			ManagesStateFile    bool     `graphql:"managesStateFile" json:"managesStateFile,omitempty"`
-			Name                string   `graphql:"name" json:"name,omitempty"`
-			Namespace           string   `graphql:"namespace" json:"namespace,omitempty"`
-			ProjectRoot         string   `graphql:"projectRoot" json:"projectRoot,omitempty"`
-			Provider            string   `graphql:"provider" json:"provider,omitempty"`
-			Repository          string   `graphql:"repository" json:"repository,omitempty"`
-			RunnerImage         string   `graphql:"runnerImage" json:"runnerImage,omitempty"`
-			Starred             bool     `graphql:"starred" json:"starred,omitempty"`
-			State               string   `graphql:"state" json:"state,omitempty"`
-			StateSetAt          int64    `graphql:"stateSetAt" json:"stateSetAt,omitempty"`
-			TerraformVersion    string   `graphql:"terraformVersion" json:"terraformVersion,omitempty"`
-			TrackedCommit       struct {
-				AuthorLogin string `graphql:"authorLogin" json:"authorLogin,omitempty"`
-				AuthorName  string `graphql:"authorName" json:"authorName,omitempty"`
-				Hash        string `graphql:"hash" json:"hash,omitempty"`
-				Message     string `graphql:"message" json:"message,omitempty"`
-				Timestamp   int64  `graphql:"timestamp" json:"timestamp,omitempty"`
-				URL         string `graphql:"url" json:"url,omitempty"`
-			} `graphql:"trackedCommit" json:"trackedCommit,omitempty"`
-			TrackedCommitSetBy string `graphql:"trackedCommitSetBy" json:"trackedCommitSetBy,omitempty"`
-			WorkerPool         struct {
-				ID   string `graphql:"id" json:"id,omitempty"`
-				Name string `graphql:"name" json:"name,omitempty"`
-			} `graphql:"workerPool" json:"workerPool,omitempty"`
-		} `graphql:"stacks" json:"stacks,omitempty"`
+		Stacks []stack `graphql:"stacks" json:"stacks,omitempty"`
 	}
 
 	if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{}); err != nil {
@@ -132,4 +81,57 @@ func listStacksTable(ctx context.Context) error {
 	}
 
 	return cmd.OutputTable(tableData, true)
+}
+
+type stack struct {
+	ID             string `graphql:"id" json:"id,omitempty"`
+	Administrative bool   `graphql:"administrative" json:"administrative,omitempty"`
+	Autodeploy     bool   `graphql:"autodeploy" json:"autodeploy,omitempty"`
+	Autoretry      bool   `graphql:"autoretry" json:"autoretry,omitempty"`
+	Blocker        struct {
+		ID string `graphql:"id" json:"id,omitempty"`
+	} `graphql:"blocker"`
+	AfterApply          []string `graphql:"afterApply" json:"afterApply,omitempty"`
+	BeforeApply         []string `graphql:"beforeApply" json:"beforeApply,omitempty"`
+	AfterInit           []string `graphql:"afterInit" json:"afterInit,omitempty"`
+	BeforeInit          []string `graphql:"beforeInit" json:"beforeInit,omitempty"`
+	AfterPlan           []string `graphql:"afterPlan" json:"afterPlan,omitempty"`
+	BeforePlan          []string `graphql:"beforePlan" json:"beforePlan,omitempty"`
+	AfterPerform        []string `graphql:"afterPerform" json:"afterPerform,omitempty"`
+	BeforePerform       []string `graphql:"beforePerform" json:"beforePerform,omitempty"`
+	AfterDestroy        []string `graphql:"afterDestroy" json:"afterDestroy,omitempty"`
+	BeforeDestroy       []string `graphql:"beforeDestroy" json:"beforeDestroy,omitempty"`
+	Branch              string   `graphql:"branch" json:"branch,omitempty"`
+	CanWrite            bool     `graphql:"canWrite" json:"canWrite,omitempty"`
+	CreatedAt           int64    `graphql:"createdAt" json:"createdAt,omitempty"`
+	Deleted             bool     `graphql:"deleted" json:"deleted,omitempty"`
+	Deleting            bool     `graphql:"deleting" json:"deleting,omitempty"`
+	Description         string   `graphql:"description" json:"description,omitempty"`
+	Labels              []string `graphql:"labels" json:"labels,omitempty"`
+	LocalPreviewEnabled bool     `graphql:"localPreviewEnabled" json:"localPreviewEnabled,omitempty"`
+	LockedBy            string   `graphql:"lockedBy" json:"lockedBy,omitempty"`
+	ManagesStateFile    bool     `graphql:"managesStateFile" json:"managesStateFile,omitempty"`
+	Name                string   `graphql:"name" json:"name,omitempty"`
+	Namespace           string   `graphql:"namespace" json:"namespace,omitempty"`
+	ProjectRoot         string   `graphql:"projectRoot" json:"projectRoot,omitempty"`
+	Provider            string   `graphql:"provider" json:"provider,omitempty"`
+	Repository          string   `graphql:"repository" json:"repository,omitempty"`
+	RunnerImage         string   `graphql:"runnerImage" json:"runnerImage,omitempty"`
+	Starred             bool     `graphql:"starred" json:"starred,omitempty"`
+	State               string   `graphql:"state" json:"state,omitempty"`
+	StateSetAt          int64    `graphql:"stateSetAt" json:"stateSetAt,omitempty"`
+	TerraformVersion    string   `graphql:"terraformVersion" json:"terraformVersion,omitempty"`
+	TrackedCommit       struct {
+		AuthorLogin string `graphql:"authorLogin" json:"authorLogin,omitempty"`
+		AuthorName  string `graphql:"authorName" json:"authorName,omitempty"`
+		Hash        string `graphql:"hash" json:"hash,omitempty"`
+		Message     string `graphql:"message" json:"message,omitempty"`
+		Timestamp   int64  `graphql:"timestamp" json:"timestamp,omitempty"`
+		URL         string `graphql:"url" json:"url,omitempty"`
+	} `graphql:"trackedCommit" json:"trackedCommit,omitempty"`
+	TrackedCommitSetBy string `graphql:"trackedCommitSetBy" json:"trackedCommitSetBy,omitempty"`
+	WorkerPool         struct {
+		ID   string `graphql:"id" json:"id,omitempty"`
+		Name string `graphql:"name" json:"name,omitempty"`
+	} `graphql:"workerPool" json:"workerPool,omitempty"`
 }

--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -1,0 +1,234 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	"github.com/pkg/errors"
+	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/client/structs"
+	"github.com/spacelift-io/spacectl/internal"
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+)
+
+func openCommandInBrowser(cliCtx *cli.Context) error {
+	ignoreSubdir := cliCtx.Bool(flagIgnoreSubdir.Name)
+	getCurrentBranch := cliCtx.Bool(flagCurrentBranch.Name)
+	count := cliCtx.Int(flagSearchCount.Name)
+
+	var subdir *string
+	if !ignoreSubdir {
+		got, err := getGitRepositorySubdir()
+		if err != nil {
+			return err
+		}
+		subdir = &got
+	}
+
+	var branch *string
+	if getCurrentBranch {
+		got, err := getGitCurrentBranch()
+		if err != nil {
+			return err
+		}
+		branch = &got
+	}
+
+	name, err := getRepositoryName()
+	if err != nil {
+		return err
+	}
+
+	return findAndSelect(cliCtx.Context, &stackSearchParams{
+		count:          count,
+		projectRoot:    subdir,
+		repositoryName: name,
+		branch:         branch,
+	})
+}
+
+func findAndSelect(ctx context.Context, p *stackSearchParams) error {
+	stacks, err := searchStacks(ctx, p)
+	if err != nil {
+		return err
+	}
+
+	items := []string{}
+	found := map[string]string{}
+	for _, stack := range stacks {
+		items = append(items, stack.Name)
+		found[stack.Name] = stack.ID
+	}
+
+	if len(found) == 0 {
+		return errors.New("Didn't find stacks")
+	}
+
+	selected := items[0]
+	if len(items) > 1 {
+		if len(items) == p.count {
+			fmt.Printf("Search results exceeded maximum capacity (%d) some stacks might be missing\n", p.count)
+		}
+
+		prompt := promptui.Select{
+			Label:             fmt.Sprintf("Found %d stacks, select one", len(items)),
+			Items:             items,
+			Size:              10,
+			StartInSearchMode: len(items) > 5,
+			Searcher: func(input string, index int) bool {
+				return strings.Contains(items[index], input)
+			},
+		}
+
+		_, result, err := prompt.Run()
+		if err != nil {
+			return err
+		}
+		selected = result
+	}
+
+	return internal.OpenWebBrowser(authenticated.Client.URL(
+		"/stack/%s",
+		found[selected],
+	))
+}
+
+// getRepositoryName calls a git command to return a url
+// for current repository origin which it parses and returnes
+// a name/repository combo. Example result: spacelift/onboarding
+func getRepositoryName() (string, error) {
+	// In future we could just parse this from .git/config
+	// but it's not that simple with submodules, this is much easier
+	// but requires `git` to be installed on users machine.
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	result := strings.SplitN(string(out), ":", 2)
+	if len(result) != 2 {
+		return "", errors.New("could not parse result")
+	}
+	return strings.TrimSuffix(strings.TrimSpace(result[1]), ".git"), nil
+}
+
+func getGitCurrentBranch() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(string(out))
+	if result == "" {
+		return "", errors.New("result for current branch is empty")
+	}
+
+	return result, nil
+}
+
+// getGitRepositorySubdir will travese the path back to .git
+// and return the path it took to get there.
+func getGitRepositorySubdir() (string, error) {
+	current, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("couldn't get current working directory: %w", err)
+	}
+
+	root := current
+	for {
+		if _, err := os.Stat(".git"); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("couldn't stat .git directory: %w", err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("couldn't get current working directory: %w", err)
+		}
+
+		parent := filepath.Dir(cwd)
+		if err := os.Chdir(parent); err != nil {
+			return "", fmt.Errorf("couldn't set current working directory: %w", err)
+		}
+		root = parent
+	}
+
+	return strings.TrimPrefix(strings.ReplaceAll(current, root, ""), "/"), nil
+}
+
+type stackSearchParams struct {
+	count int
+
+	repositoryName string
+
+	projectRoot *string
+	branch      *string
+}
+
+func searchStacks(ctx context.Context, p *stackSearchParams) ([]stack, error) {
+	var query struct {
+		SearchStacksOutput struct {
+			Edges []struct {
+				Node stack `graphql:"node"`
+			} `graphql:"edges"`
+			PageInfo structs.PageInfo `graphql:"pageInfo"`
+		} `graphql:"searchStacks(input: $input)"`
+	}
+	conditions := []structs.QueryPredicate{
+		{
+			Field: graphql.String("repository"),
+			Constraint: structs.QueryFieldConstraint{
+				StringMatches: &[]graphql.String{graphql.String(p.repositoryName)},
+			},
+		},
+	}
+
+	if p.projectRoot != nil {
+		conditions = append(conditions, structs.QueryPredicate{
+			Field: graphql.String("projectRoot"),
+			Constraint: structs.QueryFieldConstraint{
+				StringMatches: &[]graphql.String{graphql.String(*p.projectRoot)},
+			},
+		})
+	}
+
+	if p.branch != nil {
+		conditions = append(conditions, structs.QueryPredicate{
+			Field: graphql.String("branch"),
+			Constraint: structs.QueryFieldConstraint{
+				StringMatches: &[]graphql.String{graphql.String(*p.branch)},
+			},
+		})
+	}
+
+	variables := map[string]interface{}{"input": structs.SearchInput{
+		First:      graphql.NewInt(graphql.Int(p.count)),
+		Predicates: &conditions,
+	}}
+
+	if err := authenticated.Client.Query(
+		ctx,
+		&query,
+		variables,
+		graphql.WithHeader("Spacelift-GraphQL-Query", "StacksPage"),
+	); err != nil {
+		return nil, errors.Wrap(err, "failed search for stacks")
+	}
+
+	result := make([]stack, 0)
+	for _, q := range query.SearchStacksOutput.Edges {
+		result = append(result, q.Node)
+	}
+
+	return result, nil
+}

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -255,6 +255,19 @@ func Command() *cli.Command {
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
+				Category: "Stack management",
+				Name:     "open",
+				Usage:    "Open a stack in your browser",
+				Flags: []cli.Flag{
+					flagIgnoreSubdir,
+					flagCurrentBranch,
+					flagSearchCount,
+				},
+				Action:    openCommandInBrowser,
+				Before:    authenticated.Ensure,
+				ArgsUsage: "COMMAND",
+			},
+			{
 				Category: "Run management",
 				Name:     "task",
 				Usage:    "Perform a task in a workspace",


### PR DESCRIPTION
How this works:

You can navigate to any repository on your local machine and execute `stack open` which will search for a stack which was created from a git repository you're currently in and has a project root set to your current subdir.

If more than 5 results are returned a very basic search function is invoked and you are able to either filter the returned results or still use arrow keys to select.

The returned list is never longer than 10 stacks and scrolling is automatically enabled if the list is longer than that. If only 1 stack is found, we don't display anything and instantly open a browser window.




Using params you can:
* Change the count of stacks returned (only 10 are shown anyway before scrolling is enforced)
* Ignore current subdir and return all stacks for the repository
* Take current branch in to account when searching for stacks

**Caveats**

* If users have a lot of stacks from the same repo+subdir they will have to adjust count parameter and filter. Though I suspect this won't be typical.
* `git` must be installed on the machine for this to work
* Not sure how windows defender would treat these `.Exec` commands. This should be fine, but you never know.

https://github.com/spacelift-io/spacectl/issues/54