### PR TITLE
Allow to bind a specific port for login command

### DIFF
--- a/internal/cmd/profile/flags.go
+++ b/internal/cmd/profile/flags.go
@@ -1,0 +1,9 @@
+package profile
+
+import "github.com/urfave/cli/v2"
+
+var flagBindPort = &cli.IntFlag{
+	Name:     "bind",
+	Usage:    "[Optional] specify the port used for binding the server when logging in through a browser",
+	Required: false,
+}


### PR DESCRIPTION
By default we bind to a random port, but we still allow to specify a port if needed. I feel like this makes more sense than going the other way around.