### PR TITLE
Test for empty subdir when searching for stacks

### DIFF
--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -148,7 +148,7 @@ func searchStacks(ctx context.Context, p *stackSearchParams) ([]stack, error) {
 		},
 	}
 
-	if p.projectRoot != nil {
+	if p.projectRoot != nil && *p.projectRoot != "" {
 		root := strings.TrimSuffix(*p.projectRoot, "/")
 		conditions = append(conditions, structs.QueryPredicate{
 			Field: graphql.String("projectRoot"),


### PR DESCRIPTION
I was looking to see if it was possible to default the stack ID to an environment variable and found #60 but also found #125 had recently been merged so it should figure it out from the underlying cloned git repository. A new release hadn't been cut with this functionality so I tried building from source. I found `spacectl` still couldn't figure out the stack ID automatically.

All of my stacks map 1:1 with their own separate repository so the project root is unset. I found I needed to apply this small patch in order for the search to return any results.

Also, it currently always prompts me to pick the stack from the search results, even if there's only ever 1 stack returned. This looks to be caused by this condition:

https://github.com/spacelift-io/spacectl/blob/d36ea753da14b0bbfcc6f5c3ff2003fbb2800ce6/internal/cmd/stack/stack_selector.go#L68

`forcePrompt` is always `true` so it doesn't matter how many search results have been returned.