### PR TITLE
Add installation instructions with asdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ yay -S spacectl-bin
 
 Disclaimer: The package is community-maintained, please make sure to verify the [`PKGBUILD`](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=spacectl-bin) before installing/updating.
 
+### asdf
+
+```bash
+asdf plugin add spacectl
+asdf install spacectl latest
+asdf global spacectl latest
+```
+
 ### GitHub Release
 
 Alternatively, `spacectl` is distributed through GitHub Releases as a zip file containing a self-contained statically linked executable built from the source in this repository. Binaries can be download directly from the [Releases page](https://github.com/spacelift-io/spacectl/releases).


### PR DESCRIPTION
I created a [spacectl plugin](https://github.com/bodgit/asdf-spacectl) for installing `spacectl` using [asdf](https://asdf-vm.com/) and it has been added to the official community plugins, so I thought I'd add instructions to your README in case anyone else wanted to install it that way.

The plugin installs `spacectl` using the GitHub releases.