### PR TITLE
local-preview: allow packing only of the project-root

### DIFF
--- a/internal/cmd/module/local_preview.go
+++ b/internal/cmd/module/local_preview.go
@@ -51,7 +51,7 @@ func localPreview() cli.ActionFunc {
 
 		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", uploadMutation.UploadLocalWorkspace.ID))
 
-		matchFn, err := internal.GetIgnoreMatcherFn(ctx)
+		matchFn, err := internal.GetIgnoreMatcherFn(ctx, "")
 		if err != nil {
 			return fmt.Errorf("couldn't analyze .gitignore and .terraformignore files")
 		}

--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -32,6 +32,12 @@ var flagNoFindRepositoryRoot = &cli.BoolFlag{
 	Value: false,
 }
 
+var flagProjectRootOnly = &cli.BoolFlag{
+	Name:  "project-root-only",
+	Usage: "Indicate if spacelift should only package files inside this stacks project_root",
+	Value: false,
+}
+
 var flagRequiredCommitSHA = &cli.StringFlag{
 	Name:     "sha",
 	Usage:    "[Required] `SHA` of the commit to set as canonical for the stack",

--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -100,7 +100,7 @@ func getGitCurrentBranch() (string, error) {
 	return result, nil
 }
 
-// getGitRepositorySubdir will travese the path back to .git
+// getGitRepositorySubdir will traverse the path back to .git
 // and return the path it took to get there.
 func getGitRepositorySubdir() (string, error) {
 	current, err := os.Getwd()
@@ -110,22 +110,16 @@ func getGitRepositorySubdir() (string, error) {
 
 	root := current
 	for {
-		if _, err := os.Stat(".git"); err == nil {
+		if _, err := os.Stat(filepath.Join(root, ".git")); err == nil {
 			break
 		} else if !os.IsNotExist(err) {
 			return "", fmt.Errorf("couldn't stat .git directory: %w", err)
 		}
+		root = filepath.Dir(root)
+	}
 
-		cwd, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("couldn't get current working directory: %w", err)
-		}
-
-		parent := filepath.Dir(cwd)
-		if err := os.Chdir(parent); err != nil {
-			return "", fmt.Errorf("couldn't set current working directory: %w", err)
-		}
-		root = parent
+	if !strings.HasSuffix(current, "/") {
+		current = current + "/"
 	}
 
 	return strings.TrimPrefix(strings.ReplaceAll(current, root, ""), "/"), nil

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -114,6 +114,7 @@ func Command() *cli.Command {
 				Flags: []cli.Flag{
 					flagStackID,
 					flagNoFindRepositoryRoot,
+					flagProjectRootOnly,
 					flagRunMetadata,
 					flagNoTail,
 					flagNoUpload,

--- a/internal/local_preview.go
+++ b/internal/local_preview.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cheggaaa/pb/v3"
 	ignore "github.com/sabhiram/go-gitignore"
@@ -45,8 +46,10 @@ func MoveToRepositoryRoot() error {
 	}
 }
 
-// GetIgnoreMatcherFn creates an ignore-matcher for archiving purposes. Respects gitignore and terraformignore.
-func GetIgnoreMatcherFn(ctx context.Context) (func(filePath string) bool, error) {
+// GetIgnoreMatcherFn creates an ignore-matcher for archiving purposes
+// This function respects gitignore and terraformignore, and
+// optionally if a projectRoot is provided it only include files from this root
+func GetIgnoreMatcherFn(ctx context.Context, projectRoot string) (func(filePath string) bool, error) {
 	gitignore, err := ignore.CompileIgnoreFile(".gitignore")
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("couldn't compile .gitignore file: %w", err)
@@ -66,6 +69,11 @@ func GetIgnoreMatcherFn(ctx context.Context) (func(filePath string) bool, error)
 		if terraformignore != nil && terraformignore.MatchesPath(filePath) {
 			return false
 		}
+		// NOTE: this will just do a longest prefix match - does the projectRoot need to end in a slash?
+		if projectRoot != "" && !strings.HasPrefix(filePath, projectRoot) {
+			return false
+		}
+
 		return true
 	}, nil
 }


### PR DESCRIPTION
This is important to us because we use a mono repo, and we don't want to keep uploading the whole repo for each local run. This takes on average an extra 10s per run, and is problematic in low bandwidth environments.

This PR does a few things:

* adds a trailing `/` to the project root. I'm not sure what the expected behaviour is here. We could also remove the trailing slashes from the project root configurations of our stacks - but would be great if it was normalized so that this wasn't an issue.
* Allows a `project-root-only` flag that will only pack the project root for uploads. This is a 2000x reduction in upload size for our monorepo.
* fixes a bug in the `.git` detection algo where it has the side effect of also adjusting the project root.