### PR TITLE
searchStacks: append a trailing '/' to search func

### DIFF
--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -149,10 +149,11 @@ func searchStacks(ctx context.Context, p *stackSearchParams) ([]stack, error) {
 	}
 
 	if p.projectRoot != nil {
+		root := strings.TrimSuffix(*p.projectRoot, "/")
 		conditions = append(conditions, structs.QueryPredicate{
 			Field: graphql.String("projectRoot"),
 			Constraint: structs.QueryFieldConstraint{
-				StringMatches: &[]graphql.String{graphql.String(*p.projectRoot)},
+				StringMatches: &[]graphql.String{graphql.String(root), graphql.String(root + "/")},
 			},
 		})
 	}


### PR DESCRIPTION
## Problem

If there is currently a trailing `/` in the lookup path - it will not find the project root.

```
$ spacectl stack list -o json | jq -r '.[] | [.id, .projectRoot] | @csv' | head -n1
"spacelift-demo","spacelift/demo/"
```

Example failing lookup:
```
$ cd spacelift/demo
$ spacectl stack local-preview 
2023/04/04 09:40:47 no --id flag was provided and stack could not be found by searching the current directory
```

On further debugging:

When I am in the `spacelift/demo` directory, the call to `getGitRepositorySubdir` will always return `spacelift/demo`

However `findAndSelectStack` does will not match `spacelift/demo` to the stack on the server side which is stored as `spacelift/demo/`.

## Solution

This solution will also run a search for `[]string{"spacelift/demo", "spacelift/demo/"}` and do an exact match - so it still won't be fuzzy, but would still allow us to find the relevant stacks.