### PR TITLE
lightweight packaging: only upload the project_root

### DIFF
--- a/internal/cmd/module/local_preview.go
+++ b/internal/cmd/module/local_preview.go
@@ -51,7 +51,7 @@ func localPreview() cli.ActionFunc {
 
 		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", uploadMutation.UploadLocalWorkspace.ID))
 
-		matchFn, err := internal.GetIgnoreMatcherFn(ctx)
+		matchFn, err := internal.GetIgnoreMatcherFn(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("couldn't analyze .gitignore and .terraformignore files")
 		}

--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -32,6 +32,12 @@ var flagNoFindRepositoryRoot = &cli.BoolFlag{
 	Value: false,
 }
 
+var flagProjectRootOnly = &cli.BoolFlag{
+	Name:  "project-root-only",
+	Usage: "Indicate if spacelift should only package files inside this stacks project_root",
+	Value: false,
+}
+
 var flagRequiredCommitSHA = &cli.StringFlag{
 	Name:     "sha",
 	Usage:    "[Required] `SHA` of the commit to set as canonical for the stack",

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -114,6 +114,7 @@ func Command() *cli.Command {
 				Flags: []cli.Flag{
 					flagStackID,
 					flagNoFindRepositoryRoot,
+					flagProjectRootOnly,
 					flagRunMetadata,
 					flagNoTail,
 					flagNoUpload,


### PR DESCRIPTION
## Lightweight Packaging

Use cases, where we know we only need to stack `project_root` to deploy the stack successfully, this will make the upload much more efficient. In our test cases, this takes the upload from 2MB to 1/2kb for most of our stacks, so a 1000x reduction in upload bandwidth.

This is very useful in low bandwidth environments, especially in working with a mono repo.

## Solution

This currently only works for stacks, but it could probably also work with the modules pretty trivially, maybe we would want this to be the default behavior in the modules.

## Testing

I haven't got a stack that uses the root of the repo - so haven't been able to test where a stack has no project root set.