### PR TITLE
Use all relevant ignore files in archive matcher

### DIFF
--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -59,16 +59,33 @@ func localPreview() cli.ActionFunc {
 
 		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", uploadMutation.UploadLocalWorkspace.ID))
 
-		matchFn, err := internal.GetIgnoreMatcherFn(ctx, packagePath)
+		const pathToArchive = "."
+
+		absPathToArchive, err := filepath.Abs(pathToArchive)
 		if err != nil {
-			return fmt.Errorf("couldn't analyze .gitignore and .terraformignore files")
+			return fmt.Errorf("could not convert to absolute path: %w", err)
 		}
+
+		projectRoot, err := internal.FindProjectRoot(absPathToArchive)
+		if err != nil {
+			return fmt.Errorf("could not find project: %w", err)
+		}
+		project := &internal.Project{
+			RootDirectory: projectRoot,
+		}
+
+		err = project.UpdateIgnoreFiles()
+		if err != nil {
+			return fmt.Errorf("could not update ignore files: %w", err)
+		}
+
+		matchFn := project.ArchiveMatcher(absPathToArchive)
 
 		tgz := *archiver.DefaultTarGz
 		tgz.ForceArchiveImplicitTopLevelFolder = true
 		tgz.MatchFn = matchFn
 
-		if err := tgz.Archive([]string{"."}, fp); err != nil {
+		if err := tgz.Archive([]string{pathToArchive}, fp); err != nil {
 			return fmt.Errorf("couldn't archive local directory: %w", err)
 		}
 

--- a/internal/ignorefiles.go
+++ b/internal/ignorefiles.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	ignore "github.com/sabhiram/go-gitignore"
+)
+
+var skipDirs = map[string]struct{}{
+	".git": struct{}{},
+}
+
+var isIgnoreFileName = map[string]struct{}{
+	".gitignore":       struct{}{},
+	".terraformignore": struct{}{},
+}
+
+var alwaysIgnoreName = map[string]struct{}{
+	".git":       struct{}{},
+	".terraform": struct{}{},
+}
+
+type IgnoreFile interface {
+	// Matches returns `true` if the given path matches any of the patterns
+	// defined by the ignore file.
+	Matches(pathRelativeToIgnoreFile string) bool
+}
+
+type gitignoreFile struct {
+	instance *ignore.GitIgnore
+}
+
+func (gif *gitignoreFile) Matches(pathRelativeToIgnoreFile string) bool {
+	return gif.instance.MatchesPath(pathRelativeToIgnoreFile)
+}

--- a/internal/paths.go
+++ b/internal/paths.go
@@ -1,0 +1,49 @@
+package internal
+
+import (
+	"path/filepath"
+)
+
+// ParentDirectory returns the directory of the given `path`.
+//
+// If a parent directory could be found, then this function returns a non-empty
+// string and `true`.
+//
+// If a parent directory could not be found, this function returns an empty
+// string and `false`.
+//
+// That means this function returns two non-zero values on success, and two
+// zero-values on error.
+func ParentDirectory(path string) (string, bool) {
+	cleanPath := filepath.Clean(path)
+
+	// If `cleanPath` is relative, ensure it doesn't go to ".." or above.
+	if !filepath.IsAbs(cleanPath) {
+		joinedToRoot := filepath.Join("/", cleanPath)
+
+		relPath, err := filepath.Rel("/", joinedToRoot)
+		if err != nil || cleanPath != relPath {
+			return "", false
+		}
+	}
+
+	parentDir := filepath.Dir(cleanPath)
+	ok := len(parentDir) < len(cleanPath)
+	if !ok {
+		return "", false
+	}
+
+	return parentDir, true
+}
+
+// PathAncestors returns a slice containing both the directory of `initialPath`
+// and all its ancestor directories.
+func PathAncestors(initialPath string) []string {
+	var ancestors []string
+
+	for nextAncestor, ok := ParentDirectory(initialPath); ok; nextAncestor, ok = ParentDirectory(ancestors[len(ancestors)-1]) {
+		ancestors = append(ancestors, nextAncestor)
+	}
+
+	return ancestors
+}

--- a/internal/paths_test.go
+++ b/internal/paths_test.go
@@ -1,0 +1,134 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/spacelift-io/spacectl/internal"
+)
+
+func TestParentDirectory(t *testing.T) {
+	type Result struct {
+		Path string
+		OK   bool
+	}
+
+	tt := map[string]*Result{
+		"/hello/world/": &Result{
+			Path: "/hello",
+			OK:   true,
+		},
+		"/hello/world": &Result{
+			Path: "/hello",
+			OK:   true,
+		},
+		"/hello/": &Result{
+			Path: "/",
+			OK:   true,
+		},
+		"/hello": &Result{
+			Path: "/",
+			OK:   true,
+		},
+		"/": &Result{
+			Path: "",
+			OK:   false,
+		},
+		"hello/world": &Result{
+			Path: "hello",
+			OK:   true,
+		},
+		"hello": &Result{
+			Path: ".",
+			OK:   true,
+		},
+		"./hello": &Result{
+			Path: ".",
+			OK:   true,
+		},
+
+		"../../": &Result{
+			Path: "",
+			OK:   false,
+		},
+		"../..": &Result{
+			Path: "",
+			OK:   false,
+		},
+		"../": &Result{
+			Path: "",
+			OK:   false,
+		},
+		"..": &Result{
+			Path: "",
+			OK:   false,
+		},
+		"./": &Result{
+			Path: "",
+			OK:   false,
+		},
+		".": &Result{
+			Path: "",
+			OK:   false,
+		},
+		"": &Result{
+			Path: "",
+			OK:   false,
+		},
+	}
+
+	for input, wantResult := range tt {
+		wantPath := wantResult.Path
+		wantOK := wantResult.OK
+
+		gotPath, gotOK := internal.ParentDirectory(input)
+		if gotPath != wantPath || gotOK != wantOK {
+			t.Errorf("internal.ParentDirectory(%q) = (%#v, %#v); want (%#v, %#v)", input, gotPath, gotOK, wantPath, wantOK)
+		}
+	}
+}
+
+func TestPathAncestors_Absolute(t *testing.T) {
+	const input = "/hello/world/.gitignore"
+
+	possiblePaths := internal.PathAncestors(input)
+	wantPaths := []string{
+		"/hello/world",
+		"/hello",
+		"/",
+	}
+
+	if got, want := len(possiblePaths), len(wantPaths); got != want {
+		t.Fatalf("len(internal.PathAncestors(%q)) = %d; want %d", input, got, want)
+	}
+
+	for i, got := range possiblePaths {
+		want := wantPaths[i]
+
+		if got != want {
+			t.Errorf("internal.PathAncestors(%q)[%d] = %q; want %q", input, i, got, want)
+		}
+	}
+}
+
+func TestPathAncestors_Relative(t *testing.T) {
+	const input = "hello/world/.gitignore"
+
+	possiblePaths := internal.PathAncestors(input)
+	wantPaths := []string{
+		"hello/world",
+		"hello",
+		".",
+	}
+
+	if got, want := len(possiblePaths), len(wantPaths); got != want {
+		t.Fatalf("len(internal.PathAncestors(%q)) = %d; want %d", input, got, want)
+	}
+
+	for i, got := range possiblePaths {
+		want := wantPaths[i]
+
+		if got != want {
+			t.Errorf("internal.PathAncestors(%q)[%d] = %q; want %q", input, i, got, want)
+		}
+	}
+}

--- a/internal/project.go
+++ b/internal/project.go
@@ -1,0 +1,252 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ignore "github.com/sabhiram/go-gitignore"
+)
+
+var (
+	ErrNotFound              error = errors.New("not found")
+	ErrUnknownIgnoreFileType error = errors.New("unknown ignore file type")
+)
+
+// Project is a convenience struct that allows doing project-wide operations.
+//
+// The methods of this struct are NOT thread-safe.
+type Project struct {
+	RootDirectory string
+
+	// ignoreFilesByDirectory contains all known ignore files.
+	//
+	// The key of the map is a path to a directory, relative to
+	// `.RootDirectory`; the value is a slice containing all ignore files from
+	// that directory.
+	//
+	// This map is initialized by calling the `UpdateIgnoreFiles` method.
+	//
+	// This is a map because, to know whether a file is ignore or not, we only
+	// need to check the ignore files located in the same directory of that
+	// file, and any ancestor directories (i.e. never sibling directories).
+	ignoreFilesByDirectory map[string][]IgnoreFile
+}
+
+// ToRelativePath receives an absolute path, and returns a path relative to the
+// root of the project.
+func (p *Project) ToRelativePath(absPath string) (string, error) {
+	return filepath.Rel(p.RootDirectory, absPath)
+}
+
+// ToAbsolutePath receives a path relative to the project root, and returns an
+// absolute path.
+func (p *Project) ToAbsolutePath(pathRelativeToProjectRoot string) string {
+	absPath := filepath.Join(p.RootDirectory, pathRelativeToProjectRoot)
+
+	return absPath
+}
+
+// ArchiveMatcher returns a function that, when called with a path, returns
+// `true` if the path can be archived, or `false` if the path has been ignored.
+//
+// The returned function expects receiving a path relative to `referencePath`.
+//
+// This method expects `UpdateIgnoreFiles` to have been called already.
+func (p *Project) ArchiveMatcher(referencePath string) func(path string) bool {
+	absMatcherRoot := p.ToAbsolutePath(referencePath)
+
+	return func(pathToMatch string) bool {
+		absPathToMatch := filepath.Join(absMatcherRoot, pathToMatch)
+		pathRelativeToProjectRoot, err := p.ToRelativePath(absPathToMatch)
+		if err != nil {
+			return false
+		}
+
+		isIgnored, err := p.PathIsIgnored(pathRelativeToProjectRoot)
+		if err != nil {
+			return false
+		}
+		if isIgnored {
+			return false
+		}
+
+		// Ensure the root only matches the directory and not all other files.
+		root := strings.TrimSuffix(p.RootDirectory, "/") + "/"
+		if !strings.HasPrefix(pathRelativeToProjectRoot, root) {
+			return false
+		}
+
+		return true
+	}
+}
+
+func (p *Project) clearIgnoreFiles() {
+	p.ignoreFilesByDirectory = make(map[string][]IgnoreFile)
+}
+
+// addIgnoreFile receives the path to an ignore file, relative to the project
+// root, and registers it in the `*Project` struct.
+//
+// This method is not thread safe.
+func (p *Project) addIgnoreFile(pathRelativeToProjectRoot string) error {
+	absPath := filepath.Join(p.RootDirectory, pathRelativeToProjectRoot)
+
+	directory, name := filepath.Split(pathRelativeToProjectRoot)
+	if _, ok := isIgnoreFileName[name]; ok {
+		instance, err := ignore.CompileIgnoreFile(absPath)
+		if err != nil {
+			return fmt.Errorf("could not create instance for ignore file: %w", err)
+		}
+
+		var ignoreFile IgnoreFile = &gitignoreFile{
+			instance: instance,
+		}
+
+		p.ignoreFilesByDirectory[directory] = append(p.ignoreFilesByDirectory[directory], ignoreFile)
+	} else {
+		return fmt.Errorf("unsupported ignore file %#v: %w", absPath, ErrUnknownIgnoreFileType)
+	}
+
+	return nil
+}
+
+// UpdateIgnoreFiles finds all ignore files in the project, starting at the
+// project's root directory, and recursively traversing all subdirectories.
+func (p *Project) UpdateIgnoreFiles() error {
+	p.clearIgnoreFiles()
+
+	err := filepath.Walk(".", func(pathRelativeToProjectRoot string, fi fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		name := fi.Name()
+		if fi.Mode().IsRegular() {
+			if _, ok := isIgnoreFileName[name]; ok {
+				return p.addIgnoreFile(pathRelativeToProjectRoot)
+			}
+		} else if fi.IsDir() {
+			if _, ok := skipDirs[name]; ok {
+				return filepath.SkipDir
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error updating ignore files: %w", err)
+	}
+
+	return nil
+}
+
+// PathIsIgnored returns `true` if the given path is ignored by any of the
+// project's ignore files.
+func (p *Project) PathIsIgnored(pathRelativeToProjectRoot string) (bool, error) {
+	var err error
+
+	name := filepath.Base(pathRelativeToProjectRoot)
+	if _, ok := alwaysIgnoreName[name]; ok {
+		return true, nil
+	}
+
+	ancestors := PathAncestors(pathRelativeToProjectRoot)
+	for _, directory := range ancestors {
+		ignoreFiles, ok := p.ignoreFilesByDirectory[directory]
+		if !ok {
+			continue
+		}
+
+		abs := filepath.Join(p.RootDirectory, pathRelativeToProjectRoot)
+		abs, err = filepath.Abs(abs)
+		if err != nil {
+			return false, fmt.Errorf("could not find absolute path for %#v: %w", abs, err)
+		}
+
+		pathRelativeToIgnoreFile, err := filepath.Rel(directory, abs)
+		if err != nil {
+			return false, fmt.Errorf("could not convert to relative path: %#v: %w", abs, err)
+		}
+
+		for _, ignoreFile := range ignoreFiles {
+			if ignoreFile.Matches(pathRelativeToIgnoreFile) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// IsDirectory returns whether the given path is a directory or not.
+//
+// It is just a convenience function.
+func IsDirectory(path string) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not stat %#v: %w", path, err)
+	}
+
+	if !fi.IsDir() {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// FindFirstExistingDirectory receives a slice of paths, and returns the first
+// of them that is an existing directory.
+//
+// If none of the given candidates is an existing directory, it returns
+// `ErrNotFound`.
+func FindFirstExistingDirectory(candidates []string) (string, error) {
+	for _, candidate := range candidates {
+		isDirectory, err := IsDirectory(candidate)
+		if err != nil {
+			return "", fmt.Errorf("could not find first existing directory: %w", err)
+		}
+
+		if isDirectory {
+			return candidate, nil
+		}
+	}
+
+	return "", ErrNotFound
+}
+
+// FindProjectRoot tries to find the root directory of the project.
+//
+// It receives a path to any file or directory inside the project.
+func FindProjectRoot(pathInProject string) (string, error) {
+	var possibleGitPaths []string
+	pathIsDirectory, err := IsDirectory(pathInProject)
+	if err != nil {
+		return "", fmt.Errorf("could not find project root: %w", err)
+	}
+
+	if pathIsDirectory {
+		cleanPath := filepath.Clean(pathInProject)
+		cleanPath = filepath.Join(cleanPath, ".git")
+		possibleGitPaths = append(possibleGitPaths, cleanPath)
+	}
+
+	ancestors := PathAncestors(pathInProject)
+	for _, directory := range ancestors {
+		possiblePath := filepath.Join(directory, ".git")
+		possibleGitPaths = append(possibleGitPaths, possiblePath)
+	}
+
+	projectRoot, err := FindFirstExistingDirectory(possibleGitPaths)
+	if err != nil {
+		return "", fmt.Errorf("could not find project root: %w", err)
+	}
+
+	return projectRoot, nil
+}


### PR DESCRIPTION
I tried doing #138 to pass time. Most explanation is in the commit message.

But for a quick skim, start at the diff for `internal/cmd/module/local_preview.go` or `internal/cmd/stack/local_preview.go`. Specifically at the `matchFn` function.

I cannot test this because I don't have an account, and the free account sounds like a 14-day trial.

Also I'm probably missing a lot of context from the project so it's likely I'm overcomplicating this.

I hope this PR is at least a bit helpful, but if not, feel free to reject.

---

Also, I could not build the project at first because the required version of `github.com/marcinwyszynski/graphql` didn't exist (!?). I had to fix it before I could even build the `main` branch.