### PR TITLE
ci: Fix build attempt2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --clean ${{ !startsWith(github.ref, 'refs/tags/v') && '--snapshot' }}
+          args: release --clean --snapshot=${{ !startsWith(github.ref, 'refs/tags/v') }}
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The previous solution didn't work, it ended up with: `goreleaser release --clean false` which is invalid