### PR TITLE
Use ID of stack instead of name

### DIFF
--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -85,7 +85,7 @@ func findAndSelectStack(ctx context.Context, p *stackSearchParams, forcePrompt b
 			return "", err
 		}
 
-		selected = result
+		selected = found[result]
 	}
 
 	return selected, nil


### PR DESCRIPTION
This PR uses the ID of the stack (the slug) instead of the name.

Several commands were bugged by this.

Closes #137 