### PR TITLE
Add support for custom host binding with --bind-host flag and environment variables

### DIFF
--- a/internal/cmd/profile/flags.go
+++ b/internal/cmd/profile/flags.go
@@ -6,4 +6,5 @@ var flagBindPort = &cli.IntFlag{
 	Name:     "bind",
 	Usage:    "[Optional] specify the port used for binding the server when logging in through a browser",
 	Required: false,
+	EnvVars:  []string{"SPACECTL_BIND_PORT"},
 }

--- a/internal/cmd/profile/flags.go
+++ b/internal/cmd/profile/flags.go
@@ -2,9 +2,22 @@ package profile
 
 import "github.com/urfave/cli/v2"
 
+var bindHost string
+var flagBindHost = &cli.StringFlag{
+	Name:        "bind-host",
+	Usage:       "[Optional] specify the host used for binding the server when logging in through a browser",
+	Required:    false,
+	Value:       "localhost",
+	Destination: &bindHost,
+	EnvVars:     []string{"SPACECTL_BIND_HOST"},
+}
+
+var bindPort int
 var flagBindPort = &cli.IntFlag{
-	Name:     "bind",
-	Usage:    "[Optional] specify the port used for binding the server when logging in through a browser",
-	Required: false,
-	EnvVars:  []string{"SPACECTL_BIND_PORT"},
+	Name:        "bind",
+	Usage:       "[Optional] specify the port used for binding the server when logging in through a browser",
+	Required:    false,
+	Value:       0,
+	Destination: &bindPort,
+	EnvVars:     []string{"SPACECTL_BIND_PORT"},
 }

--- a/internal/cmd/profile/login_command.go
+++ b/internal/cmd/profile/login_command.go
@@ -38,6 +38,7 @@ func loginCommand() *cli.Command {
 		ArgsUsage: "<account-alias>",
 		Action:    loginAction,
 		Flags: []cli.Flag{
+			flagBindHost,
 			flagBindPort,
 		},
 	}
@@ -222,13 +223,7 @@ func loginUsingWebBrowser(ctx *cli.Context, creds *session.StoredCredentials) er
 		done <- true
 	}
 
-	var bindOn *int
-	if ctx.IsSet(flagBindPort.Name) {
-		port := ctx.Int(flagBindPort.Name)
-		bindOn = &port
-	}
-
-	server, port, err := serveOnOpenPort(bindOn, handler)
+	server, port, err := serveOnOpenPort(&bindHost, &bindPort, handler)
 	if err != nil {
 		return err
 	}
@@ -283,11 +278,9 @@ func persistAccessCredentials(creds *session.StoredCredentials) error {
 	})
 }
 
-func serveOnOpenPort(port *int, handler func(w http.ResponseWriter, r *http.Request)) (*http.Server, int, error) {
-	bindOn := "localhost:0"
-	if port != nil {
-		bindOn = fmt.Sprintf("localhost:%d", *port)
-	}
+func serveOnOpenPort(host *string, port *int, handler func(w http.ResponseWriter, r *http.Request)) (*http.Server, int, error) {
+
+	bindOn := fmt.Sprintf("%s:%d", *host, *port)
 
 	addr, err := net.ResolveTCPAddr("tcp", bindOn)
 	if err != nil {


### PR DESCRIPTION
## What

- Add new `--bind-host` flag to allow the user to bind to a host other than `localhost`
- Add the ability to specify the `--bind` flag via `SPACECTL_BIND_PORT` and the new `--bind-host` via `SPACECTL_BIND_HOST` environment variables

## Why

When running `spacectl` in a docker environment such as [Cloud Posse's Geodesic](https://github.com/cloudposse/geodesic), `localhost` isn't available outside of the container, so we have to bind to `0.0.0.0`. The new functionality gives us the ability to do the following:

```bash
# /etc/profile
export SPACECTL_BIND_HOST=0.0.0.0
export SPACECTL_BIND_PORT=$(command to get the mapped port docker is listening on)
```

Then we can just use the `spacectl profile login` anywhere within the container and it will work as expected.