### PR TITLE
Don't exit when failing to open a browser during login

### DIFF
--- a/internal/cmd/profile/login_command.go
+++ b/internal/cmd/profile/login_command.go
@@ -237,8 +237,7 @@ func loginUsingWebBrowser(ctx *cli.Context, creds *session.StoredCredentials) er
 	fmt.Printf("\nOpening browser to %s\n\n", browserURL)
 
 	if err := browser.OpenURL(browserURL); err != nil {
-		server.Close()
-		return err
+		fmt.Printf("Failed to open the browser: %s\nPlease open the URL manually\n\n", err.Error())
 	}
 
 	fmt.Println("Waiting for login...")


### PR DESCRIPTION
https://github.com/spacelift-io/spacectl/issues/152

Failing to open a browser will now print:
```

Failed to open the browser: exec: "xdg-open,x-www-browser,www-browser": executable file not found in $PATH
Please open the URL manually

Waiting for login...
```