### PR TITLE
add check for empty environment variables

### DIFF
--- a/client/session/from_environment.go
+++ b/client/session/from_environment.go
@@ -54,7 +54,7 @@ func FromEnvironment(ctx context.Context, client *http.Client) func(func(string)
 		}
 
 		endpoint, ok := lookup(EnvSpaceliftAPIKeyEndpoint)
-		if !ok {
+		if !ok || endpoint == "" {
 			// Keep backwards compatibility with older version of spacectl.
 			endpoint, ok = lookup(EnvSpaceliftAPIEndpoint)
 			if !ok {

--- a/client/session/from_environment.go
+++ b/client/session/from_environment.go
@@ -37,9 +37,9 @@ const (
 )
 
 var (
-	ErrEnvSpaceliftAPIKeyID       = fmt.Errorf("%s missing from the environment", EnvSpaceliftAPIKeyID)
-	ErrEnvSpaceliftAPIKeySecret   = fmt.Errorf("%s missing from the environment", EnvSpaceliftAPIKeySecret)
-	ErrEnvSpaceliftAPIKeyEndpoint = fmt.Errorf("%s missing from the environment", EnvSpaceliftAPIKeyEndpoint)
+	errEnvSpaceliftAPIKeyID       = fmt.Errorf("%s missing from the environment", EnvSpaceliftAPIKeyID)
+	errEnvSpaceliftAPIKeySecret   = fmt.Errorf("%s missing from the environment", EnvSpaceliftAPIKeySecret)
+	errEnvSpaceliftAPIKeyEndpoint = fmt.Errorf("%s missing from the environment", EnvSpaceliftAPIKeyEndpoint)
 )
 
 // FromEnvironment creates a Spacelift session from the environment.
@@ -58,7 +58,7 @@ func FromEnvironment(ctx context.Context, client *http.Client) func(func(string)
 			// Keep backwards compatibility with older version of spacectl.
 			endpoint, ok = lookup(EnvSpaceliftAPIEndpoint)
 			if !ok {
-				return nil, ErrEnvSpaceliftAPIKeyEndpoint
+				return nil, errEnvSpaceliftAPIKeyEndpoint
 			}
 			fmt.Printf("Environment variable %q is deprecated, please use %q\n", EnvSpaceliftAPIEndpoint, EnvSpaceliftAPIKeyEndpoint)
 		}
@@ -70,12 +70,12 @@ func FromEnvironment(ctx context.Context, client *http.Client) func(func(string)
 
 		keyID, ok := lookup(EnvSpaceliftAPIKeyID)
 		if !ok || keyID == "" {
-			return nil, ErrEnvSpaceliftAPIKeyID
+			return nil, errEnvSpaceliftAPIKeyID
 		}
 
 		keySecret, ok := lookup(EnvSpaceliftAPIKeySecret)
 		if !ok || keySecret == "" {
-			return nil, ErrEnvSpaceliftAPIKeySecret
+			return nil, errEnvSpaceliftAPIKeySecret
 		}
 
 		return FromAPIKey(ctx, client)(endpoint, keyID, keySecret)

--- a/client/session/from_environment_test.go
+++ b/client/session/from_environment_test.go
@@ -3,12 +3,13 @@ package session
 import (
 	"context"
 	"github.com/franela/goblin"
-	"strings"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
 // lookupWithEnv creates a custom lookup func which will return desired test values
-func lookupWithEnv(envSpaceliftAPIToken, envSpaceliftAPIKeyID, envSpaceliftAPIKeySecret string) func(e string) (string, bool) {
+func lookupWithEnv(envSpaceliftAPIKeyEndpoint, envSpaceliftAPIToken, envSpaceliftAPIKeyID, envSpaceliftAPIKeySecret string) func(e string) (string, bool) {
 	return func(e string) (string, bool) {
 		s := ""
 		b := false
@@ -18,7 +19,7 @@ func lookupWithEnv(envSpaceliftAPIToken, envSpaceliftAPIKeyID, envSpaceliftAPIKe
 			s = envSpaceliftAPIToken
 			b = true
 		case EnvSpaceliftAPIKeyEndpoint:
-			s = "https://spacectl.app.spacelift.io"
+			s = envSpaceliftAPIKeyEndpoint
 			b = true
 		case EnvSpaceliftAPIKeyID:
 			s = envSpaceliftAPIKeyID
@@ -37,44 +38,60 @@ func TestFromEnvironment(t *testing.T) {
 
 	g.Describe("FromEnvironment", func() {
 		g.Describe("EnvSpaceliftAPIKeyEndpoint is not set", func() {
+			l := lookupWithEnv("", "", "abc123", "SuperSecret")
 			g.It("expect an error to find api endpoint in environment", func() {
-				_, err := FromEnvironment(context.TODO(), nil)(func(s string) (string, bool) {
-					return "", false
-				})
+				_, err := FromEnvironment(context.TODO(), nil)(l)
 				g.Assert(err).Equal(ErrEnvSpaceliftAPIKeyEndpoint)
 			})
 		})
 
 		g.Describe("EnvSpaceliftAPIToken is set, EnvSpaceliftAPIKeyID is set, EnvSpaceliftAPIKeySecret is set", func() {
-			l := lookupWithEnv("abc123", "abc123", "SuperSecret")
 			g.It("expect EnvSpaceliftAPIToken to be used and EnvSpaceliftAPIKeyID and EnvSpaceliftAPIKeySecret to be ignored", func() {
-				_, err := FromEnvironment(context.TODO(), nil)(l)
-				// only looking at the error prefix because the suffix is set outside of this package and is out of our control
-				g.Assert(strings.Split(err.Error(), ":")[0]).Equal("could not parse the API token")
+				// Create a mock http server to handle JWT exchange
+				server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+					rw.Write([]byte(`{"data":{"apiKeyUser":{"jwt":"SuperSecretJWT","validUntil":123}}}`))
+				}))
+				// Close the server when test finishes
+				defer server.Close()
+				// API Token JWT generated at https://jwt.io/#debugger-io with contents:
+				//     Header: {"alg": "HS256","typ": "JWT"}
+				//     Payload: {"aud": "spacectl","exp": 1516239022}
+				l := lookupWithEnv(server.URL, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJzcGFjZWN0bCIsImV4cCI6MTUxNjIzOTAyMn0.fsKd_N2TKXpx83JSPPw47zYzQ8sbSzGVPZcyGpwp05U", "abc123", "SuperSecret")
+				s, err := FromEnvironment(context.TODO(), server.Client())(l)
+				g.Assert(err).IsNil("expected no error when creating session")
+				g.Assert(s.Type()).Equal(CredentialsTypeAPIToken)
 			})
 		})
 
 		g.Describe("EnvSpaceliftAPIToken is an empty string", func() {
 			g.Describe("EnvSpaceliftAPIKeyID is set, EnvSpaceliftAPIKeySecret is set", func() {
-				l := lookupWithEnv("", "abc123", "SuperSecret")
-				g.It("expect an exchange error because we're using fake credentials, this proves that EnvSpaceliftAPIKeyID and EnvSpaceliftAPIKeySecret are being used", func() {
-					_, err := FromEnvironment(context.TODO(), nil)(l)
-					// only looking at the error prefix because the suffix is set outside of this package and is out of our control
-					g.Assert(strings.Split(err.Error(), ":")[0]).Equal("could not exchange API key and secret for token")
+				g.It("expect a CredentialsTypeAPIKey session to be created", func() {
+					// Create a mock http server to handle JWT exchange
+					server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+						rw.Write([]byte(`{"data":{"apiKeyUser":{"jwt":"SuperSecretJWT","validUntil":123}}}`))
+					}))
+					// Close the server when test finishes
+					defer server.Close()
+
+					l := lookupWithEnv(server.URL, "", "abc123", "SuperSecret")
+
+					s, err := FromEnvironment(context.TODO(), server.Client())(l)
+					g.Assert(err).IsNil("expected no error when creating session")
+					g.Assert(s.Type()).Equal(CredentialsTypeAPIKey)
 				})
 			})
 
 			g.Describe("EnvSpaceliftAPIKeyID is an empty string, EnvSpaceliftAPIKeySecret is set", func() {
-				l := lookupWithEnv("", "", "SuperSecret")
 				g.It("expect an error to find api key id in environment", func() {
+					l := lookupWithEnv("https://spacectl.app.spacelift.io", "", "", "SuperSecret")
 					_, err := FromEnvironment(context.TODO(), nil)(l)
 					g.Assert(err).Equal(ErrEnvSpaceliftAPIKeyID)
 				})
 			})
 
 			g.Describe("EnvSpaceliftAPIKeyID is set, EnvSpaceliftAPIKeySecret is an empty string", func() {
-				l := lookupWithEnv("", "abc123", "")
 				g.It("expect an error to find api key secret in environment", func() {
+					l := lookupWithEnv("https://spacectl.app.spacelift.io", "", "abc123", "")
 					_, err := FromEnvironment(context.TODO(), nil)(l)
 					g.Assert(err).Equal(ErrEnvSpaceliftAPIKeySecret)
 				})

--- a/client/session/from_environment_test.go
+++ b/client/session/from_environment_test.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"context"
+	"github.com/franela/goblin"
+	"strings"
+	"testing"
+)
+
+// lookupWithEnv creates a custom lookup func which will return desired test values
+func lookupWithEnv(envSpaceliftAPIToken, envSpaceliftAPIKeyID, envSpaceliftAPIKeySecret string) func(e string) (string, bool) {
+	return func(e string) (string, bool) {
+		s := ""
+		b := false
+
+		switch e {
+		case EnvSpaceliftAPIToken:
+			s = envSpaceliftAPIToken
+			b = true
+		case EnvSpaceliftAPIKeyEndpoint:
+			s = "https://spacectl.app.spacelift.io"
+			b = true
+		case EnvSpaceliftAPIKeyID:
+			s = envSpaceliftAPIKeyID
+			b = true
+		case EnvSpaceliftAPIKeySecret:
+			s = envSpaceliftAPIKeySecret
+			b = true
+		}
+
+		return s, b
+	}
+}
+
+func TestFromEnvironment(t *testing.T) {
+	g := goblin.Goblin(t)
+
+	g.Describe("FromEnvironment", func() {
+		g.Describe("EnvSpaceliftAPIKeyEndpoint is not set", func() {
+			g.It("expect an error to find api endpoint in environment", func() {
+				_, err := FromEnvironment(context.TODO(), nil)(func(s string) (string, bool) {
+					return "", false
+				})
+				g.Assert(err).Equal(ErrEnvSpaceliftAPIKeyEndpoint)
+			})
+		})
+
+		g.Describe("EnvSpaceliftAPIToken is set, EnvSpaceliftAPIKeyID is set, EnvSpaceliftAPIKeySecret is set", func() {
+			l := lookupWithEnv("abc123", "abc123", "SuperSecret")
+			g.It("expect EnvSpaceliftAPIToken to be used and EnvSpaceliftAPIKeyID and EnvSpaceliftAPIKeySecret to be ignored", func() {
+				_, err := FromEnvironment(context.TODO(), nil)(l)
+				// only looking at the error prefix because the suffix is set outside of this package and is out of our control
+				g.Assert(strings.Split(err.Error(), ":")[0]).Equal("could not parse the API token")
+			})
+		})
+
+		g.Describe("EnvSpaceliftAPIToken is an empty string", func() {
+			g.Describe("EnvSpaceliftAPIKeyID is set, EnvSpaceliftAPIKeySecret is set", func() {
+				l := lookupWithEnv("", "abc123", "SuperSecret")
+				g.It("expect an exchange error because we're using fake credentials, this proves that EnvSpaceliftAPIKeyID and EnvSpaceliftAPIKeySecret are being used", func() {
+					_, err := FromEnvironment(context.TODO(), nil)(l)
+					// only looking at the error prefix because the suffix is set outside of this package and is out of our control
+					g.Assert(strings.Split(err.Error(), ":")[0]).Equal("could not exchange API key and secret for token")
+				})
+			})
+
+			g.Describe("EnvSpaceliftAPIKeyID is an empty string, EnvSpaceliftAPIKeySecret is set", func() {
+				l := lookupWithEnv("", "", "SuperSecret")
+				g.It("expect an error to find api key id in environment", func() {
+					_, err := FromEnvironment(context.TODO(), nil)(l)
+					g.Assert(err).Equal(ErrEnvSpaceliftAPIKeyID)
+				})
+			})
+
+			g.Describe("EnvSpaceliftAPIKeyID is set, EnvSpaceliftAPIKeySecret is an empty string", func() {
+				l := lookupWithEnv("", "abc123", "")
+				g.It("expect an error to find api key secret in environment", func() {
+					_, err := FromEnvironment(context.TODO(), nil)(l)
+					g.Assert(err).Equal(ErrEnvSpaceliftAPIKeySecret)
+				})
+			})
+		})
+	})
+}

--- a/client/session/from_environment_test.go
+++ b/client/session/from_environment_test.go
@@ -41,7 +41,7 @@ func TestFromEnvironment(t *testing.T) {
 			l := lookupWithEnv("", "", "abc123", "SuperSecret")
 			g.It("expect an error to find api endpoint in environment", func() {
 				_, err := FromEnvironment(context.TODO(), nil)(l)
-				g.Assert(err).Equal(ErrEnvSpaceliftAPIKeyEndpoint)
+				g.Assert(err).Equal(errEnvSpaceliftAPIKeyEndpoint)
 			})
 		})
 
@@ -85,7 +85,7 @@ func TestFromEnvironment(t *testing.T) {
 				g.It("expect an error to find api key id in environment", func() {
 					l := lookupWithEnv("https://spacectl.app.spacelift.io", "", "", "SuperSecret")
 					_, err := FromEnvironment(context.TODO(), nil)(l)
-					g.Assert(err).Equal(ErrEnvSpaceliftAPIKeyID)
+					g.Assert(err).Equal(errEnvSpaceliftAPIKeyID)
 				})
 			})
 
@@ -93,7 +93,7 @@ func TestFromEnvironment(t *testing.T) {
 				g.It("expect an error to find api key secret in environment", func() {
 					l := lookupWithEnv("https://spacectl.app.spacelift.io", "", "abc123", "")
 					_, err := FromEnvironment(context.TODO(), nil)(l)
-					g.Assert(err).Equal(ErrEnvSpaceliftAPIKeySecret)
+					g.Assert(err).Equal(errEnvSpaceliftAPIKeySecret)
 				})
 			})
 		})


### PR DESCRIPTION
I would like to execute some `spacectl` commands in custom workflow steps (pre-init, pre-plan, etc) within some spacelift stacks. In spacelift stacks the `SPACELIFT_API_TOKEN` environment variable exists by default with a `<computed>` value, but unfortunately this value doesn't have sufficient permissions to work with the way spacectl authenticates. Ideally this problem would be resolved, but I don't understand that problem.

Therefore, I want to use the `SPACELIFT_API_KEY_ID` and `SPACELIFT_API_KEY_SECRET` variables in my stack to authenticate spacectl. There isn't a way to unset the `SPACELIFT_API_TOKEN` computed environment variable that exists by default on spacelift stacks. If the `SPACELIFT_API_TOKEN` environment variable exists with an empty value then it will still take precedence over the `SPACELIFT_API_KEY_ID` and `SPACELIFT_API_KEY_SECRET` variables. 

This PR adds code to check if any of the environment variables which spacectl uses to authenticate are set to an empty string. If a variable is set to an empty string then the variable will be ignored and considered as unset. This should allow me to use the `SPACELIFT_API_KEY_ID` and `SPACELIFT_API_KEY_SECRET` variables in my spacelift stacks.