### PR TITLE
Always pass state version when getting run logs

### DIFF
--- a/client/structs/run_state_transition.go
+++ b/client/structs/run_state_transition.go
@@ -8,12 +8,13 @@ import (
 
 // RunStateTransition represents a single run state transition.
 type RunStateTransition struct {
-	HasLogs   bool     `graphql:"hasLogs"`
-	Note      *string  `graphql:"note"`
-	State     RunState `graphql:"state"`
-	Terminal  bool     `graphql:"terminal"`
-	Timestamp int      `graphql:"timestamp"`
-	Username  *string  `graphql:"username"`
+	HasLogs      bool     `graphql:"hasLogs"`
+	Note         *string  `graphql:"note"`
+	State        RunState `graphql:"state"`
+	StateVersion int      `graphql:"stateVersion"`
+	Terminal     bool     `graphql:"terminal"`
+	Timestamp    int      `graphql:"timestamp"`
+	Username     *string  `graphql:"username"`
 }
 
 // About returns "header" information about the state transition.

--- a/internal/cmd/stack/run_logs.go
+++ b/internal/cmd/stack/run_logs.go
@@ -76,7 +76,7 @@ func runStates(ctx context.Context, stack, run string, sink chan<- string) (*str
 			fmt.Println("")
 
 			if transition.HasLogs {
-				if err := runStateLogs(ctx, stack, run, transition.State, sink); err != nil {
+				if err := runStateLogs(ctx, stack, run, transition.State, transition.StateVersion, sink); err != nil {
 					return nil, err
 				}
 			}
@@ -94,7 +94,7 @@ func runStates(ctx context.Context, stack, run string, sink chan<- string) (*str
 	}
 }
 
-func runStateLogs(ctx context.Context, stack, run string, state structs.RunState, sink chan<- string) error {
+func runStateLogs(ctx context.Context, stack, run string, state structs.RunState, version int, sink chan<- string) error {
 	var query struct {
 		Stack *struct {
 			Run *struct {
@@ -106,18 +106,18 @@ func runStateLogs(ctx context.Context, stack, run string, state structs.RunState
 						Body string `graphql:"message"`
 					} `graphql:"messages"`
 					NextToken *graphql.String `graphql:"nextToken"`
-				} `graphql:"logs(state: $state, token: $token)"`
+				} `graphql:"logs(state: $state, token: $token, stateVersion: $stateVersion)"`
 			} `graphql:"run(id: $run)"`
 		} `graphql:"stack(id: $stack)"`
 	}
 
 	var token *graphql.String
-
 	variables := map[string]interface{}{
-		"stack": graphql.ID(stack),
-		"run":   graphql.ID(run),
-		"state": state,
-		"token": token,
+		"stack":        graphql.ID(stack),
+		"run":          graphql.ID(run),
+		"state":        state,
+		"token":        token,
+		"stateVersion": graphql.Int(version),
 	}
 
 	var backOff time.Duration


### PR DESCRIPTION
We've added to repeat the same state for a run which requires you to provide the state version when getting logs. This adds the state version to the request.