### PR TITLE
Allow to predefine login actions

### DIFF
--- a/internal/cmd/profile/flags.go
+++ b/internal/cmd/profile/flags.go
@@ -1,6 +1,12 @@
 package profile
 
-import "github.com/urfave/cli/v2"
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/client/session"
+)
 
 var bindHost string
 var flagBindHost = &cli.StringFlag{
@@ -20,4 +26,42 @@ var flagBindPort = &cli.IntFlag{
 	Value:       0,
 	Destination: &bindPort,
 	EnvVars:     []string{"SPACECTL_BIND_PORT"},
+}
+
+const (
+	methodBrowser = "browser"
+	methodAPI     = "api"
+	methodGithub  = "github"
+)
+
+var methodToCredentialsType = map[string]session.CredentialsType{
+	methodGithub:  session.CredentialsTypeGitHubToken,
+	methodAPI:     session.CredentialsTypeAPIKey,
+	methodBrowser: session.CredentialsTypeAPIToken,
+}
+
+var flagMethod = &cli.StringFlag{
+	Name:     "method",
+	Usage:    "[Optional] the method to use for logging in to Spacelift",
+	Required: false,
+	EnvVars:  []string{"SPACECTL_LOGIN_METHOD"},
+	Action: func(ctx *cli.Context, v string) error {
+		if v == "" {
+			return nil
+		}
+
+		switch v {
+		case methodBrowser, methodAPI, methodGithub:
+			return nil
+		default:
+			return fmt.Errorf("flag 'method' was provided an invalid value, possible values: %s, %s %s", methodBrowser, methodAPI, methodGithub)
+		}
+	},
+}
+
+var flagEndpoint = &cli.StringFlag{
+	Name:     "endpoint",
+	Usage:    "[Optional] the endpoint to use for logging in to Spacelift",
+	Required: false,
+	EnvVars:  []string{"SPACECTL_LOGIN_ENDPOINT"},
 }


### PR DESCRIPTION
Added the ability to predefine the login path to take using flags, this allows for a quicker way to login with less clicking:
* You can define the `--endpoint` to skip the need to enter the spacelift url.
* You can define the `--method` to skip the choice of login method.
* You can define both the values above to skip both steps.

Also removed the confusing loop and updated selection for the login method to a prettier menu.


Command example:
```
spacectl profile login --method browser --endpoint https://unicorn.app.spacelift.io  local-test
```

Closes: https://github.com/spacelift-io/spacectl/issues/158