### PR TITLE
Allow to disregard the gitignore file during local preview file packing

### DIFF
--- a/internal/cmd/module/flags.go
+++ b/internal/cmd/module/flags.go
@@ -35,3 +35,8 @@ var flagVersion = &cli.StringFlag{
 	Usage: "Semver `version` for the module version. If not provided, the version " +
 		"from the configuration file will be used",
 }
+
+var flagDisregardGitignore = &cli.BoolFlag{
+	Name:  "disregard-gitignore",
+	Usage: "[Optional] Disregard the .gitignore file when reading files in a directory",
+}

--- a/internal/cmd/module/local_preview.go
+++ b/internal/cmd/module/local_preview.go
@@ -51,7 +51,12 @@ func localPreview() cli.ActionFunc {
 
 		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", uploadMutation.UploadLocalWorkspace.ID))
 
-		matchFn, err := internal.GetIgnoreMatcherFn(ctx, nil)
+		ignoreFiles := []string{".terraformignore"}
+		if !cliCtx.IsSet(flagDisregardGitignore.Name) {
+			ignoreFiles = append(ignoreFiles, ".gitignore")
+		}
+
+		matchFn, err := internal.GetIgnoreMatcherFn(ctx, nil, ignoreFiles)
 		if err != nil {
 			return fmt.Errorf("couldn't analyze .gitignore and .terraformignore files")
 		}

--- a/internal/cmd/module/module.go
+++ b/internal/cmd/module/module.go
@@ -35,6 +35,7 @@ func Command() *cli.Command {
 					flagNoFindRepositoryRoot,
 					flagNoUpload,
 					flagRunMetadata,
+					flagDisregardGitignore,
 				},
 				Action:    localPreview(),
 				Before:    authenticated.Ensure,

--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -124,3 +124,8 @@ var flagOverrideEnvVars = &cli.StringSliceFlag{
 	Name:  "env-var-override",
 	Usage: "[Optional] Environment variables injected into the run at runtime, example: --env-var-override 'foo=bar,bar=baz'",
 }
+
+var flagDisregardGitignore = &cli.BoolFlag{
+	Name:  "disregard-gitignore",
+	Usage: "[Optional] Disregard the .gitignore file when reading files in a directory",
+}

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -66,7 +66,12 @@ func localPreview() cli.ActionFunc {
 
 		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", uploadMutation.UploadLocalWorkspace.ID))
 
-		matchFn, err := internal.GetIgnoreMatcherFn(ctx, packagePath)
+		ignoreFiles := []string{".terraformignore"}
+		if !cliCtx.IsSet(flagDisregardGitignore.Name) {
+			ignoreFiles = append(ignoreFiles, ".gitignore")
+		}
+
+		matchFn, err := internal.GetIgnoreMatcherFn(ctx, nil, ignoreFiles)
 		if err != nil {
 			return fmt.Errorf("couldn't analyze .gitignore and .terraformignore files")
 		}

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -120,6 +120,7 @@ func Command() *cli.Command {
 					flagNoUpload,
 					flagOverrideEnvVars,
 					flagOverrideEnvVarsTF,
+					flagDisregardGitignore,
 				},
 				Action:    localPreview(),
 				Before:    authenticated.Ensure,


### PR DESCRIPTION
This is a feature request from customers. Sometimes you want to not commit files to git, but still include them when running local preview. Using the new flag you can do just that.

Example with debugging prints:
```
➜  named_hooks git:(allow-to-ignore-gitignore) ✗ spacectl stack local-preview  --id=subdir
Packing local workspace...
built file: .terraformignore
built file: .gitignore
Ignoring file: modules/test
Ignoring file: modules/test/.spacelift
Ignoring file: modules/test/.spacelift/config.yml
Ignoring file: modules/test/examples
Ignoring file: modules/test/examples/simple-usage
Ignoring file: modules/test/examples/simple-usage/main.tf
Ignoring file: modules/test/main.tf
Ignoring file: modules/test/outputs.tf
Ignoring file: modules/test/variables.tf
Uploading local workspace...

^C
➜  named_hooks git:(allow-to-ignore-gitignore) ✗ spacectl stack local-preview  --id=subdir --disregard-gitignore
Packing local workspace...
built file: .terraformignore
Uploading local workspace...
```