### PR TITLE
Fix brew deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,7 @@ changelog:
 
 brews:
   - name: "{{ .ProjectName }}"
-    tap:
+    repository:
       owner: "spacelift-io"
       name: "homebrew-spacelift"
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
Renaming `brews.tap` to `brews.repository` to fix the [deprecation](https://goreleaser.com/deprecations/#brewstap) [warning](https://github.com/spacelift-io/spacectl/actions/runs/5692666279/job/15430125477#step:10:29).