### PR TITLE
Allow to get latest logs for a stack

### DIFF
--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -52,7 +52,12 @@ var flagRequiredRun = &cli.StringFlag{
 
 var flagRun = &cli.StringFlag{
 	Name:  "run",
-	Usage: "`ID` of the run",
+	Usage: "[Optional] `ID` of the run",
+}
+
+var flagRunLatest = &cli.BoolFlag{
+	Name:  "run-latest",
+	Usage: "[Optional] Indicates that the latest run should be used",
 }
 
 var flagNoInit = &cli.BoolFlag{

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -1,8 +1,6 @@
 package stack
 
 import (
-	"context"
-
 	"github.com/urfave/cli/v2"
 
 	"github.com/spacelift-io/spacectl/internal/cmd"
@@ -133,16 +131,10 @@ func Command() *cli.Command {
 				Usage:    "Show logs for a particular run",
 				Flags: []cli.Flag{
 					flagStackID,
-					flagRequiredRun,
+					flagRun,
+					flagRunLatest,
 				},
-				Action: func(cliCtx *cli.Context) error {
-					stackID, err := getStackID(cliCtx)
-					if err != nil {
-						return err
-					}
-					_, err = runLogsWithAction(context.Background(), stackID, cliCtx.String(flagRequiredRun.Name), nil)
-					return err
-				},
+				Action:    runLogs,
 				Before:    authenticated.Ensure,
 				ArgsUsage: cmd.EmptyArgsUsage,
 			},


### PR DESCRIPTION
Instead of looking up all runs and picking the latest one, allow to provide a flag to query the latest run for the user and just get those logs. This is the most common use case for the command anyway.