### PR TITLE
Use filepath functions for path manipulation in getGitRepositorySubdir

### DIFF
--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -122,6 +122,13 @@ func getGitRepositorySubdir() (string, error) {
 		} else if !os.IsNotExist(err) {
 			return "", fmt.Errorf("couldn't stat .git directory: %w", err)
 		}
+
+		if newRoot := filepath.Dir(root); newRoot != root {
+			root = newRoot
+		} else {
+			return "", fmt.Errorf("couldn't find .git directory in %s or any of its parents", current)
+		}
+
 		root = filepath.Dir(root)
 	}
 

--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -130,6 +130,10 @@ func getGitRepositorySubdir() (string, error) {
 		return "", fmt.Errorf("couldn't get relative path: %w", err)
 	}
 
+	if pathWithoutRoot == "." {
+		return "", nil
+	}
+
 	return filepath.ToSlash(pathWithoutRoot), nil
 }
 

--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -125,7 +125,12 @@ func getGitRepositorySubdir() (string, error) {
 		root = filepath.Dir(root)
 	}
 
-	return strings.TrimPrefix(strings.ReplaceAll(current, root, ""), "/"), nil
+	pathWithoutRoot, err := filepath.Rel(root, current)
+	if err != nil {
+		return "", fmt.Errorf("couldn't get relative path: %w", err)
+	}
+
+	return filepath.ToSlash(pathWithoutRoot), nil
 }
 
 type stackSearchParams struct {


### PR DESCRIPTION
Before this commit, the root directory would be removed which leaves a trailing file separator character in the beginning. This would then be trimmed by using strings.TrimPrefix. The problem here is that it uses a hardcoded file separator character which won't work on Windows because Windows uses a backslash instead of a forward slash.

Using filepath.Rel to get the directory relative to the root directory will not leave a separator character in the beginning.

It's also important to use filepath.ToSlash which will translate every file separator character to the forward slash.

This commit makes discovery work on Windows which it didn't before.