### PR TITLE
Remove double call to flepath.Dir in getGitRepositorySubdir

### DIFF
--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -128,8 +128,6 @@ func getGitRepositorySubdir() (string, error) {
 		} else {
 			return "", fmt.Errorf("couldn't find .git directory in %s or any of its parents", current)
 		}
-
-		root = filepath.Dir(root)
 	}
 
 	pathWithoutRoot, err := filepath.Rel(root, current)


### PR DESCRIPTION
I forgot to remove the unchecked call to `filepath.Dir` in my previous pull request.