### PR TITLE
Improve user facing error massage when the stack is not found

### DIFF
--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -61,11 +61,7 @@ func localPreview() cli.ActionFunc {
 		}
 
 		if err := authenticated.Client.Mutate(ctx, &uploadMutation, uploadVariables); err != nil {
-			baseErrorMessage := "failed to upload local workspace"
-			if strings.Contains(err.Error(), "not found") {
-				return fmt.Errorf("%s: stack with ID %q could not be found. Please check that the stack exists and that you have access to it. To list available stacks run: spacectl stack list", baseErrorMessage, stackID)
-			}
-			return fmt.Errorf("%s: %w", baseErrorMessage, err)
+			return fmt.Errorf("failed to upload local workspace: %w", err)
 		}
 
 		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", uploadMutation.UploadLocalWorkspace.ID))

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -61,7 +61,11 @@ func localPreview() cli.ActionFunc {
 		}
 
 		if err := authenticated.Client.Mutate(ctx, &uploadMutation, uploadVariables); err != nil {
-			return err
+			baseErrorMessage := "failed to upload local workspace"
+			if strings.Contains(err.Error(), "not found") {
+				return fmt.Errorf("%s: stack with ID %q could not be found. Please check that the stack exists and that you have access to it. To list available stacks run: spacectl stack list", baseErrorMessage, stackID)
+			}
+			return fmt.Errorf("%s: %w", baseErrorMessage, err)
 		}
 
 		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", uploadMutation.UploadLocalWorkspace.ID))

--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -75,7 +75,7 @@ func stackExists(ctx context.Context, stackId string) error {
 
 	err := authenticated.Client.Query(ctx, &query, variables)
 	if err != nil {
-		return fmt.Errorf("failed to query GraphQL API: %w", err)
+		return fmt.Errorf("failed to query GraphQL API when checking if a stack exists: %w", err)
 	}
 
 	if query.Stack.ID == "" {

--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -8,8 +8,9 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 var errNoStackFound = errors.New("no stack found")

--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -73,10 +73,7 @@ func stackExists(ctx context.Context, stackId string) (bool, error) {
 		return false, fmt.Errorf("failed to query GraphQL API when checking if a stack exists: %w", err)
 	}
 
-	if query.Stack.ID == "" {
-		return false, nil
-	}
-	return true, nil
+	return query.Stack.ID != "", nil
 }
 
 func findAndSelectStack(ctx context.Context, p *stackSearchParams, forcePrompt bool) (string, error) {

--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -27,7 +27,7 @@ func getStackID(cliCtx *cli.Context) (string, error) {
 			return "", fmt.Errorf("failed to check if stack exists: %w", err)
 		}
 		if !exists {
-			return "", fmt.Errorf("Stack with id %q could not be found. Please check that the stack exists and that you have access to it. To list available stacks run: spacectl stack list", stackID)
+			return "", fmt.Errorf("stack with id %q could not be found. Please check that the stack exists and that you have access to it. To list available stacks run: spacectl stack list", stackID)
 		}
 		return stackID, nil
 	}

--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -20,15 +20,15 @@ var errNoStackFound = errors.New("no stack found")
 // 2. Check the current directory to determine repository and subdirectory and search for a stack.
 func getStackID(cliCtx *cli.Context) (string, error) {
 	if cliCtx.IsSet(flagStackID.Name) {
-		stackId := cliCtx.String(flagStackID.Name)
-		exists, err := stackExists(cliCtx.Context, stackId)
+		stackID := cliCtx.String(flagStackID.Name)
+		exists, err := stackExists(cliCtx.Context, stackID)
 		if err != nil {
 			return "", fmt.Errorf("failed to check if stack exists: %w", err)
 		}
 		if !exists {
-			return "", fmt.Errorf("Stack with id %q could not be found. Please check that the stack exists and that you have access to it. To list available stacks run: spacectl stack list", stackId)
+			return "", fmt.Errorf("Stack with id %q could not be found. Please check that the stack exists and that you have access to it. To list available stacks run: spacectl stack list", stackID)
 		}
-		return stackId, nil
+		return stackID, nil
 	}
 
 	subdir, err := getGitRepositorySubdir()
@@ -57,7 +57,7 @@ func getStackID(cliCtx *cli.Context) (string, error) {
 	return got, nil
 }
 
-func stackExists(ctx context.Context, stackId string) (bool, error) {
+func stackExists(ctx context.Context, stackID string) (bool, error) {
 	var query struct {
 		Stack struct {
 			ID string `graphql:"id"`
@@ -65,7 +65,7 @@ func stackExists(ctx context.Context, stackId string) (bool, error) {
 	}
 
 	variables := map[string]interface{}{
-		"id": graphql.ID(stackId),
+		"id": graphql.ID(stackID),
 	}
 
 	err := authenticated.Client.Query(ctx, &query, variables)


### PR DESCRIPTION
closes: https://app.clickup.com/t/862k09kgc

Includes in the error message a hint about how to list available stacks.

Note: The GraphQL API doesn't return errors that can be typed. The string parsing is a dirty hack, if anyone knows of a better way to approach it let me know.