### PR TITLE
Support for structured logging

### DIFF
--- a/client/session/interface.go
+++ b/client/session/interface.go
@@ -2,7 +2,8 @@ package session
 
 import (
 	"context"
-	"log"
+	"log/slog"
+	"os"
 )
 
 // Session is an abstraction around session creation based on credentials from
@@ -16,7 +17,8 @@ type Session interface {
 // Must provides a helper that either creates a Session or dies trying.
 func Must(out Session, err error) Session {
 	if err != nil {
-		log.Fatalf("Could not create a Spacelift session: %v", err)
+		slog.Error("Could not create a Spacelift session", "err", err)
+		os.Exit(1)
 	}
 
 	return out

--- a/internal/cmd/module/local_preview.go
+++ b/internal/cmd/module/local_preview.go
@@ -3,11 +3,13 @@ package module
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,7 +17,6 @@ import (
 	"github.com/mholt/archiver/v3"
 	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
@@ -131,7 +132,8 @@ func localPreview() cli.ActionFunc {
 					})
 				}
 				if err := g.Wait(); err != nil {
-					log.Fatal("couldn't get runs: ", err)
+					slog.Error("couldn't get runs", "err", err)
+					os.Exit(1)
 				}
 				model.setRuns(newRuns)
 			}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -19,11 +19,15 @@ import (
 
 var version = "dev"
 var date = "2006-01-02T15:04:05Z"
+var loggingLevel = new(slog.LevelVar)
 
 func main() {
+
 	compileTime, err := time.Parse(time.RFC3339, date)
+
 	if err != nil {
-		log.Fatalf("Could not parse compilation date: %v", err)
+		slog.Error("Could not parse compilation date", "err", err)
+		os.Exit(1)
 	}
 	app := &cli.App{
 		Name:     "spacectl",
@@ -40,9 +44,58 @@ func main() {
 			versioncmd.Command(version),
 			workerpools.Command(),
 		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "log-format",
+				Aliases: []string{"f"},
+				Usage:   "Log format: json, text",
+				Value:   "text",
+			},
+			&cli.StringFlag{
+				Name:    "log-level",
+				Aliases: []string{"l"},
+				Usage:   "Log level: debug, info, warn, error",
+				Value:   "info",
+			},
+		},
+		Before: func(c *cli.Context) error {
+			var logger *slog.Logger
+			switch c.String("log-format") {
+			case "json":
+				logger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+					AddSource: true,
+					Level:     loggingLevel,
+				}))
+			case "text":
+				logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+					AddSource: true,
+					Level:     loggingLevel,
+				}))
+			default:
+				return cli.Exit("Invalid log format", 1)
+			}
+
+			switch c.String("log-level") {
+			case "debug":
+				loggingLevel.Set(slog.LevelDebug)
+			case "info":
+				loggingLevel.Set(slog.LevelInfo)
+			case "warn":
+				loggingLevel.Set(slog.LevelWarn)
+			case "error":
+				loggingLevel.Set(slog.LevelError)
+			default:
+				return cli.Exit("Invalid log level", 1)
+			}
+
+			slog.SetDefault(logger)
+
+			return nil
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
+		slog.Error("error", "err", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
- adds support for structured (JSON) logs
- adds support for levelled logging
- switches to using slog


Note: there's 74 candidates for switching from fmt.Println to log.* 
```
> grep -riI 'fmt\.' . | grep -v "return" | grep -v "fmt.Spr" | grep -v "fmt.Erro" | wc -l
74
```
 If we decide to do it, I think it should be in a separate PR.