### PR TITLE
Allow to cancel runs

### DIFF
--- a/internal/cmd/stack/run_cancel.go
+++ b/internal/cmd/stack/run_cancel.go
@@ -1,0 +1,56 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+)
+
+func runCancel() cli.ActionFunc {
+	return func(cliCtx *cli.Context) error {
+		stackID, err := getStackID(cliCtx)
+		if err != nil {
+			return err
+		}
+
+		var mutation struct {
+			RunDiscard struct {
+				ID string `graphql:"id"`
+			} `graphql:"runCancel(stack: $stack, run: $run)"`
+		}
+
+		variables := map[string]interface{}{
+			"stack": graphql.ID(stackID),
+			"run":   graphql.ID(cliCtx.String(flagRequiredRun.Name)),
+		}
+
+		ctx := context.Background()
+
+		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+			return err
+		}
+
+		fmt.Println("You have successfully canceled the run")
+
+		fmt.Println("The run can be visited at", authenticated.Client.URL(
+			"/stack/%s/run/%s",
+			stackID,
+			mutation.RunDiscard.ID,
+		))
+
+		if !cliCtx.Bool(flagTail.Name) {
+			return nil
+		}
+
+		terminal, err := runLogsWithAction(ctx, stackID, mutation.RunDiscard.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		return terminal.Error()
+	}
+}

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -42,6 +42,19 @@ func Command() *cli.Command {
 			},
 			{
 				Category: "Run management",
+				Name:     "cancel",
+				Usage:    "Cancel a run that hasn't started yet",
+				Flags: []cli.Flag{
+					flagStackID,
+					flagRequiredRun,
+					flagTail,
+				},
+				Action:    runCancel(),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+			{
+				Category: "Run management",
 				Name:     "approve",
 				Usage:    "Approves a run or task. If no run is specified, the approval will be added to the current stack blocker.",
 				Flags: []cli.Flag{


### PR DESCRIPTION
```
➜ spc stack cancel --id testing-component --run 01HCHMRJ9JF64E41B4NR5FQ87Q
You have successfully canceled a run
The run can be visited at http://tomasmik.app.spacelift.tf/stack/testing-component/run/01HCHMRJ9JF64E41B4NR5FQ87Q

➜ spc stack cancel --id testing-component --run 01HCHMZWE9CAVKGWHN2E2CZ7K3 --tail
You have successfully canceled a run
The run can be visited at http://tomasmik.app.spacelift.tf/stack/testing-component/run/01HCHMZWE9CAVKGWHN2E2CZ7K3

-----------------
QUEUED	Thu Oct 12 12:55:23 EEST 2023
-----------------

-----------------
CANCELED	Fri Oct 13 12:49:40 EEST 2023	api::01HBR32BK0ZD84TB1DKF83D760
-----------------

2023/10/13 12:49:40 finished with CANCELED state
```

Fixes: https://github.com/spacelift-io/spacectl/issues/193