### PR TITLE
Improve repository name detection

### DIFF
--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -85,11 +85,24 @@ func getRepositoryName() (string, error) {
 		return "", err
 	}
 
-	result := strings.SplitN(string(out), ":", 2)
-	if len(result) != 2 {
-		return "", errors.New("could not parse result")
+	return cleanupRepositoryString(string(out))
+}
+
+func cleanupRepositoryString(s string) (string, error) {
+	var userRepo string
+
+	switch {
+	case strings.HasPrefix(s, "https://"):
+		userRepo = strings.TrimPrefix(s, "https://")
+		userRepo = userRepo[strings.Index(userRepo, "/")+1:]
+	case strings.HasPrefix(s, "git@"):
+		userRepo = strings.TrimPrefix(s, "git@")
+		userRepo = userRepo[strings.Index(userRepo, ":")+1:]
+	default:
+		return "", fmt.Errorf("unsupported repository string: %s", s)
 	}
-	return strings.TrimSuffix(strings.TrimSpace(result[1]), ".git"), nil
+
+	return strings.TrimSuffix(strings.TrimSpace(userRepo), ".git"), nil
 }
 
 func getGitCurrentBranch() (string, error) {

--- a/internal/cmd/stack/open_command_test.go
+++ b/internal/cmd/stack/open_command_test.go
@@ -1,0 +1,24 @@
+package stack
+
+import "testing"
+
+func Test_cleanupRepositoryString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"https://github.com/username/tftest.git", "username/tftest"},
+		{"git@github.com:username/spacelift-local.git", "username/spacelift-local"},
+		{"https://gitlab.com/username/project.git", "username/project"},
+		{"git@gitlab.com:username/project.git", "username/project"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result, _ := cleanupRepositoryString(test.input)
+			if result != test.expected {
+				t.Errorf("expected %q, got %q", test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Problem before was that it only worked if you were using ssh. Now it works with https as well. This isn't very flashy code, but it works and it has a test.

Closes: https://github.com/spacelift-io/spacectl/issues/232