### PR TITLE
Allow for mTLS connections configured from environment

### DIFF
--- a/internal/cmd/authenticated/client.go
+++ b/internal/cmd/authenticated/client.go
@@ -55,7 +55,9 @@ func Ensure(*cli.Context) error {
 
 // configureTLS configures client TLS from the environment.
 func configureTLS(httpClient *http.Client) error {
-	clientTLS := &tls.Config{}
+	clientTLS := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 
 	if caFile, ok := os.LookupEnv(EnvSpaceliftAPIClientCA); ok && caFile != "" {
 		caCert, err := os.ReadFile("cacert")


### PR DESCRIPTION
Created an example PR for issue: https://github.com/spacelift-io/spacectl/issues/236 in which you can configure Client TLS settings through environment variables. Let me know if this is contribution you would be willing to accept or if I should request this feature through other channels. 

Additionally, there might be improved UX if the client certs could be linked to a particular profile as well although I didn't explore that in this PR. 