### PR TITLE
Use http.DefaultTransport when adding mTLS connections

### DIFF
--- a/internal/cmd/authenticated/client.go
+++ b/internal/cmd/authenticated/client.go
@@ -85,9 +85,10 @@ func configureTLS(httpClient *http.Client) error {
 		clientTLS.Certificates = []tls.Certificate{cert}
 	}
 
-	httpClient.Transport = &http.Transport{
-		TLSClientConfig: clientTLS,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = clientTLS
+
+	httpClient.Transport = transport
 
 	return nil
 }


### PR DESCRIPTION
Followup to https://github.com/spacelift-io/spacectl/pull/237 that I missed. Instead of completely overriding the Transport to one that doesn't have timeouts configured. Clone the default transport and override that instead. 