### PR TITLE
fix: Watch log hangs when we're in a terminal state

### DIFF
--- a/internal/cmd/stack/run_logs.go
+++ b/internal/cmd/stack/run_logs.go
@@ -129,7 +129,7 @@ func runStates(ctx context.Context, stack, run string, sink chan<- string, acFn 
 			fmt.Println("")
 
 			if transition.HasLogs {
-				if err := runStateLogs(ctx, stack, run, transition.State, transition.StateVersion, sink); err != nil {
+				if err := runStateLogs(ctx, stack, run, transition.State, transition.StateVersion, sink, transition.Terminal); err != nil {
 					return nil, err
 				}
 			}
@@ -153,7 +153,7 @@ func runStates(ctx context.Context, stack, run string, sink chan<- string, acFn 
 	}
 }
 
-func runStateLogs(ctx context.Context, stack, run string, state structs.RunState, version int, sink chan<- string) error {
+func runStateLogs(ctx context.Context, stack, run string, state structs.RunState, version int, sink chan<- string, stateTerminal bool) error {
 	var query struct {
 		Stack *struct {
 			Run *struct {
@@ -205,7 +205,7 @@ func runStateLogs(ctx context.Context, stack, run string, state structs.RunState
 			sink <- message.Body
 		}
 
-		if logs.Finished {
+		if logs.Finished || (!logs.HasMore && stateTerminal) {
 			break
 		}
 


### PR DESCRIPTION
If we have no more logs and we're in a terminal state, don't wait for more, just exit. This fixes the problem of local preview not exiting.


```
....
╷
│ Error: Unsupported block type
│
│   on main.tf line 1:
│    1: aarsource "random_string" "random" {
│
│ Blocks of type "aarsource" are not expected here.
╵

[01J6F1AVF3VFZ7NZ7K4EMEKMW6] Unexpected exit code when initializing workspace: 1

-----------------
FAILED	Thu Aug 29 15:35:31 EEST 2024
-----------------

View full logs at http://*.app.spacelift.tf/stack/doublestack/run/01J6F2462RPSAPFCRY6GMP2FPT
2024/08/29 15:35:32 finished with FAILED state
➜  $

```

This was reported by a customer.

Closes: https://github.com/spacelift-io/spacectl/issues/250