### PR TITLE
Allow to delete a module version

### DIFF
--- a/internal/cmd/module/delete_version.go
+++ b/internal/cmd/module/delete_version.go
@@ -1,0 +1,32 @@
+package module
+
+import (
+	"fmt"
+
+	"github.com/shurcooL/graphql"
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+	"github.com/urfave/cli/v2"
+)
+
+func deleteVersion(cliCtx *cli.Context) error {
+	moduleID := cliCtx.String(flagModuleID.Name)
+	versionID := cliCtx.String(flagVersionID.Name)
+
+	var mutation struct {
+		DeleteModuleVersion struct {
+			Number string `graphql:"number"`
+		} `graphql:"versionDelete(id: $id, module: $module)"`
+	}
+
+	variables := map[string]interface{}{
+		"id":     graphql.ID(versionID),
+		"module": graphql.ID(moduleID),
+	}
+
+	if err := authenticated.Client.Mutate(cliCtx.Context, &mutation, variables); err != nil {
+		return err
+	}
+
+	fmt.Printf("Module version %q has been deleted\n", mutation.DeleteModuleVersion.Number)
+	return nil
+}

--- a/internal/cmd/module/flags.go
+++ b/internal/cmd/module/flags.go
@@ -8,6 +8,12 @@ var flagModuleID = &cli.StringFlag{
 	Required: true,
 }
 
+var flagVersionID = &cli.StringFlag{
+	Name:     "versionid",
+	Usage:    "[Required] User-facing `ID` (slug) of the version",
+	Required: true,
+}
+
 var flagCommitSHA = &cli.StringFlag{
 	Name:  "sha",
 	Usage: "Commit `SHA` to use for the module version",

--- a/internal/cmd/module/module.go
+++ b/internal/cmd/module/module.go
@@ -27,6 +27,18 @@ func Command() *cli.Command {
 			},
 			{
 				Category: "Module management",
+				Name:     "delete-version",
+				Usage:    "Delete a version of a module",
+				Flags: []cli.Flag{
+					flagModuleID,
+					flagVersionID,
+				},
+				Action:    deleteVersion,
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+			{
+				Category: "Module management",
 				Name:     "local-preview",
 				Usage:    "Start a preview (proposed version) based on the current project. Respects .gitignore and .terraformignore.",
 				Flags: []cli.Flag{


### PR DESCRIPTION
```bash
➜  spc module delete-version --id gitlbam --versionid 01J537F77FRHBXVSEPXWNGFBX4
Module version "1.7.5" has been deleted
```

We already allow you to create versions using spacectl, so let's allow you to delete them as well.

Closes: https://github.com/spacelift-io/spacectl/issues/254