### PR TITLE
Allow auto-select for stackID when only finding one stack

### DIFF
--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -19,7 +19,7 @@ var (
 )
 
 const (
-	envPropmtSkipKey = "SPACECTL_SKIP_STACK_PROMPT"
+	envPromptSkipKey = "SPACECTL_SKIP_STACK_PROMPT"
 )
 
 // getStackID will try to retrieve a stack ID from multiple sources.
@@ -71,7 +71,7 @@ func getStack(cliCtx *cli.Context) (*stack, error) {
 		return nil, err
 	}
 
-	skip := os.Getenv(envPropmtSkipKey) == "true"
+	skip := os.Getenv(envPromptSkipKey) == "true"
 
 	got, err := findAndSelectStack(cliCtx.Context, &stackSearchParams{
 		count:          50,
@@ -191,7 +191,7 @@ func findAndSelectStack(ctx context.Context, p *stackSearchParams, forcePrompt b
 			fmt.Printf("Search results exceeded maximum capacity (%d) some stacks might be missing\n", p.count)
 		}
 		if len(items) == 1 && forcePrompt {
-			fmt.Printf("Enable auto-selection by setting '%s=true'\n", envPropmtSkipKey)
+			fmt.Printf("Enable auto-selection by setting '%s=true'\n", envPromptSkipKey)
 		}
 
 		prompt := promptui.Select{

--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -3,6 +3,7 @@ package stack
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/manifoldco/promptui"
@@ -15,6 +16,10 @@ import (
 
 var (
 	errNoStackFound = errors.New("no stack found")
+)
+
+const (
+	envPropmtSkipKey = "SPACECTL_SKIP_STACK_PROMPT"
 )
 
 // getStackID will try to retrieve a stack ID from multiple sources.
@@ -66,11 +71,13 @@ func getStack(cliCtx *cli.Context) (*stack, error) {
 		return nil, err
 	}
 
+	skip := os.Getenv(envPropmtSkipKey) == "true"
+
 	got, err := findAndSelectStack(cliCtx.Context, &stackSearchParams{
 		count:          50,
 		projectRoot:    &subdir,
 		repositoryName: name,
-	}, true)
+	}, !skip)
 	if err != nil {
 		if errors.Is(err, errNoStackFound) {
 			return nil, fmt.Errorf("%w: no --id flag was provided and stack could not be found by searching the current directory", err)
@@ -182,6 +189,9 @@ func findAndSelectStack(ctx context.Context, p *stackSearchParams, forcePrompt b
 	if len(items) > 1 || forcePrompt {
 		if len(items) == p.count {
 			fmt.Printf("Search results exceeded maximum capacity (%d) some stacks might be missing\n", p.count)
+		}
+		if len(items) == 1 && forcePrompt {
+			fmt.Printf("Enable auto-selection by setting '%s=true'\n", envPropmtSkipKey)
 		}
 
 		prompt := promptui.Select{


### PR DESCRIPTION
```
➜  empty git:(diff) ✗ /Users/tomas/spacelift-io/spacectl/build/aa stack show
Enable auto-selection by setting SPACECTL_SKIP_STACK_PROMPT=true
Use the arrow keys to navigate: ↓ ↑ → ←  and / toggles search
? Found 1 stacks, select one:
  ▸ doublestack
2024/09/27 14:49:35 ^C
➜  empty git:(diff) ✗ SPACECTL_SKIP_STACK_PROMPT=true
➜  empty git:(diff) ✗ /Users/tomas/spacelift-io/spacectl/build/aa stack show

Provider   | GitHub
Repository | empty
Branch     | master
```

closes: https://github.com/spacelift-io/spacectl/issues/259