### PR TITLE
Return an error when one then more alias is provided

### DIFF
--- a/internal/cmd/profile/get_alias.go
+++ b/internal/cmd/profile/get_alias.go
@@ -6,16 +6,20 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var (
-	profileAlias string
-)
+var profileAlias string
 
-func getAlias(cliCtx *cli.Context) error {
-	if nArgs := cliCtx.NArg(); nArgs != 1 {
-		return fmt.Errorf("expecting profile alias as the only argument, got %d instead", nArgs)
+// setGlobalProfileAlias sets the global profile alias if it is provided as the only argument.
+// It returns false if no arguments were provided and error if there were more than one.
+//
+// If false is returned, the caller should attempt to get the profile alias on its own.
+func setGlobalProfileAlias(cliCtx *cli.Context) (bool, error) {
+	switch cliCtx.NArg() {
+	case 0:
+		return false, nil
+	case 1:
+		profileAlias = cliCtx.Args().Get(0)
+		return true, nil
+	default:
+		return false, fmt.Errorf("expecting profile alias as the only argument, got %d instead", cliCtx.NArg())
 	}
-
-	profileAlias = cliCtx.Args().Get(0)
-
-	return nil
 }

--- a/internal/cmd/profile/get_alias_with_profile.go
+++ b/internal/cmd/profile/get_alias_with_profile.go
@@ -13,7 +13,12 @@ var (
 )
 
 func getAliasWithAPITokenProfile(cliCtx *cli.Context) error {
-	if err := getAlias(cliCtx); err == nil {
+	ok, err := setGlobalProfileAlias(cliCtx)
+	if err != nil {
+		return err
+	}
+
+	if ok {
 		return nil
 	}
 

--- a/internal/cmd/profile/logout_command.go
+++ b/internal/cmd/profile/logout_command.go
@@ -9,7 +9,10 @@ func logoutCommand() *cli.Command {
 		Name:      "logout",
 		Usage:     "Remove Spacelift credentials for an existing profile",
 		ArgsUsage: "<account-alias>",
-		Before:    getAlias,
+		Before: func(cliCtx *cli.Context) error {
+			_, err := setGlobalProfileAlias(cliCtx)
+			return err
+		},
 		Action: func(*cli.Context) error {
 			return manager.Delete(profileAlias)
 		},

--- a/internal/cmd/profile/select_command.go
+++ b/internal/cmd/profile/select_command.go
@@ -9,7 +9,10 @@ func selectCommand() *cli.Command {
 		Name:      "select",
 		Usage:     "Select one of your Spacelift account profiles",
 		ArgsUsage: "<account-alias>",
-		Before:    getAlias,
+		Before: func(cliCtx *cli.Context) error {
+			_, err := setGlobalProfileAlias(cliCtx)
+			return err
+		},
 		Action: func(*cli.Context) error {
 			return manager.Select(profileAlias)
 		},


### PR DESCRIPTION
```
➜  spacectl git:(fix-alias) ✗ ./spc profile login asdf asdf
2024/11/07 11:07:40 expecting profile alias as the only argument, got 2 instead
➜  spacectl git:(fix-alias) ✗ ./spc profile login myorg
Enter Spacelift endpoint (eg. https://unicorn.app.spacelift.io/): https://tomasmik.app.spacelift.tf/
➜  spacectl git:(fix-alias) ✗ ./spc profile login
Waiting for login responses at 127.0.0.1:65014
```