### PR TITLE
Allow to target resources when running local-preview

### DIFF
--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -32,6 +32,11 @@ var flagNoFindRepositoryRoot = &cli.BoolFlag{
 	Value: false,
 }
 
+var flagTarget = &cli.StringSliceFlag{
+	Name:  "target",
+	Usage: "List of targets to use during local preview, read more here: https://spacelift.io/blog/terraform-target",
+}
+
 var flagProjectRootOnly = &cli.BoolFlag{
 	Name:  "project-root-only",
 	Usage: "Indicate if spacelift should only package files inside this stacks project_root",

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -21,6 +21,18 @@ func localPreview() cli.ActionFunc {
 			return err
 		}
 
+		if got := cliCtx.StringSlice(flagTarget.Name); len(got) > 0 {
+			var val string
+			for _, v := range got {
+				val = strings.Join([]string{val, "-target=" + v}, " ")
+			}
+
+			envVars = append(envVars, EnvironmentVariable{
+				Key:   "TF_CLI_ARGS_plan",
+				Value: graphql.String(strings.TrimSpace(val)),
+			})
+		}
+
 		stack, err := getStack(cliCtx)
 		if err != nil {
 			return err

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -162,6 +162,7 @@ func Command() *cli.Command {
 					flagOverrideEnvVarsTF,
 					flagDisregardGitignore,
 					flagPrioritizeRun,
+					flagTarget,
 				},
 				Action:    localPreview(),
 				Before:    authenticated.Ensure,


### PR DESCRIPTION
This was suggested by people in the issue comments. I tested it and it works just fine. I've updated the resources:
```sh
--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,18 @@
 resource "random_string" "random" {
-  length           = 12
+  length           = 112
   special          = true
   override_special = "/@£$"
 }

 resource "random_string" "random2" {
-  length           = 11
+  length           = 10
   special          = true
   override_special = "/@£$"
 }


 resource "random_string" "random3" {
-  length           = 13
+  length           = 19
   special          = true
   override_special = "/@£$"
 }
 ```
 
When calling `spc stack local-preview -target="random_string.random,random_string.random2"`, my plan looks like this:
 
<img width="587" alt="image" src="https://github.com/user-attachments/assets/692b2cbb-ad4c-4094-a854-7e85a8f0dddc">
