### PR TITLE
feat: use register platform v2 mutation

### DIFF
--- a/internal/cmd/provider/create_version.go
+++ b/internal/cmd/provider/create_version.go
@@ -75,12 +75,12 @@ func createVersion() cli.ActionFunc {
 		}
 
 		fmt.Println("Uploading the checksums file")
-		if err := checksumsFile.Upload(cliCtx.Context, dir, createMutation.CreateTerraformProviderVersion.SHA256SumsUploadURL, checksumsFile.MetadataHeaders()); err != nil {
+		if err := checksumsFile.Upload(cliCtx.Context, dir, createMutation.CreateTerraformProviderVersion.SHA256SumsUploadURL, checksumsFile.AWSMetadataHeaders()); err != nil {
 			return errors.Wrap(err, "could not upload checksums file")
 		}
 
 		fmt.Println("Uploading the signatures file")
-		if err := signatureFile.Upload(cliCtx.Context, dir, createMutation.CreateTerraformProviderVersion.SHA256SumsSigUploadURL, signatureFile.MetadataHeaders()); err != nil {
+		if err := signatureFile.Upload(cliCtx.Context, dir, createMutation.CreateTerraformProviderVersion.SHA256SumsSigUploadURL, signatureFile.AWSMetadataHeaders()); err != nil {
 			return errors.Wrap(err, "could not upload signature file")
 		}
 
@@ -156,7 +156,7 @@ func registerPlatform(ctx context.Context, dir string, versionID string, artifac
 		return err
 	}
 
-	if err := artifact.Upload(ctx, dir, mutation.RegisterTerraformProviderVersionPlatform, artifact.MetadataHeaders()); err != nil {
+	if err := artifact.Upload(ctx, dir, mutation.RegisterTerraformProviderVersionPlatform, artifact.AWSMetadataHeaders()); err != nil {
 		return errors.Wrapf(err, "could not upload artifact: %s", artifact.Name)
 	}
 

--- a/internal/cmd/provider/flags.go
+++ b/internal/cmd/provider/flags.go
@@ -42,6 +42,11 @@ var flagProviderType = &cli.StringFlag{
 	Required: true,
 }
 
+var flagUseRegisterPlatformV2 = &cli.BoolFlag{
+	Name:  "use-register-platform-v2",
+	Usage: "Use register platform v2 mutation",
+}
+
 var flagProviderVersionProtocols = &cli.StringSliceFlag{
 	Name:  "protocols",
 	Usage: "Terraform plugin protocols supported by the provider",

--- a/internal/cmd/provider/internal/goreleaser.go
+++ b/internal/cmd/provider/internal/goreleaser.go
@@ -140,7 +140,7 @@ func (a *GoReleaserArtifact) Checksum(dir string) (string, error) {
 }
 
 // Upload uploads the artifact's content to the given URL using HTTP PUT method.
-func (a *GoReleaserArtifact) Upload(ctx context.Context, dir string, url string) error {
+func (a *GoReleaserArtifact) Upload(ctx context.Context, dir string, url string, header http.Header) error {
 	content, err := a.content(dir)
 	if err != nil {
 		return errors.Wrapf(err, "could not get artifact content for %s", a.Name)
@@ -157,16 +157,8 @@ func (a *GoReleaserArtifact) Upload(ctx context.Context, dir string, url string)
 		return errors.Wrapf(err, "could not create request for %s", a.Name)
 	}
 
-	if a.OS != nil {
-		request.Header.Set("x-amz-meta-binary-os", *a.OS)
-	}
-
-	if a.Arch != nil {
-		request.Header.Set("x-amz-meta-binary-architecture", *a.Arch)
-	}
-
-	if checksum := a.Extra.Checksum.BinarySHA256(); checksum != "" {
-		request.Header.Set("x-amz-meta-binary-checksum", checksum)
+	for k := range header {
+		request.Header.Set(k, header.Get(k))
 	}
 
 	response, err := http.DefaultClient.Do(request)
@@ -185,6 +177,22 @@ func (a *GoReleaserArtifact) Upload(ctx context.Context, dir string, url string)
 	}
 
 	return nil
+}
+
+func (a *GoReleaserArtifact) MetadataHeaders() http.Header {
+	headers := http.Header{}
+	if a.OS != nil {
+		headers.Set("x-amz-meta-binary-os", *a.OS)
+	}
+
+	if a.Arch != nil {
+		headers.Set("x-amz-meta-binary-architecture", *a.Arch)
+	}
+
+	if checksum := a.Extra.Checksum.BinarySHA256(); checksum != "" {
+		headers.Set("x-amz-meta-binary-checksum", checksum)
+	}
+	return headers
 }
 
 // ValidateFilename validates that the artifact's name matches the expected

--- a/internal/cmd/provider/internal/goreleaser.go
+++ b/internal/cmd/provider/internal/goreleaser.go
@@ -179,7 +179,9 @@ func (a *GoReleaserArtifact) Upload(ctx context.Context, dir string, url string,
 	return nil
 }
 
-func (a *GoReleaserArtifact) MetadataHeaders() http.Header {
+// AWSMetadataHeaders returns the headers required for uploading with an AWS presigned URL.
+// Deprecated: Use UploadHeaders from the gql TerraformProviderVersionRegisterPlatformV2 response instead.
+func (a *GoReleaserArtifact) AWSMetadataHeaders() http.Header {
 	headers := http.Header{}
 	if a.OS != nil {
 		headers.Set("x-amz-meta-binary-os", *a.OS)

--- a/internal/cmd/provider/provider.go
+++ b/internal/cmd/provider/provider.go
@@ -54,6 +54,7 @@ func Command() *cli.Command {
 					flagProviderVersionProtocols,
 					flagGoReleaserDir,
 					flagGPGKeyID,
+					flagUseRegisterPlatformV2,
 				},
 				Action:    createVersion(),
 				Before:    authenticated.Ensure,


### PR DESCRIPTION
Add ability to use the registerPlatformV2 mutation in the create version command.
The new mutation returns a set of headers that are required to include in the upload request.

Regarding versioning, the current implementation defaults to v1. The v2 logic is enabled when the flag is passed. In the future, we can reverse this behavior by making v2 the default logic while allowing users to revert to v1 using a new flag.