### PR TITLE
fix: check for register platform v2 mutation

### DIFF
--- a/internal/cmd/provider/create_version.go
+++ b/internal/cmd/provider/create_version.go
@@ -20,7 +20,7 @@ func createVersion() cli.ActionFunc {
 		dir := cliCtx.String(flagGoReleaserDir.Name)
 
 		providerType := cliCtx.String(flagProviderType.Name)
-		useRegisterPlatformV2 := cliCtx.Bool(flagUseRegisterPlatformV2.Name)
+		var useRegisterPlatformV2 bool
 		if types, err := mutationTypes(cliCtx.Context); err == nil {
 			useRegisterPlatformV2 = types.hasTerraformProviderVersionRegisterPlatformV2Mutation()
 		} else {

--- a/internal/cmd/provider/create_version.go
+++ b/internal/cmd/provider/create_version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
@@ -20,6 +21,11 @@ func createVersion() cli.ActionFunc {
 
 		providerType := cliCtx.String(flagProviderType.Name)
 		useRegisterPlatformV2 := cliCtx.Bool(flagUseRegisterPlatformV2.Name)
+		if types, err := mutationTypes(cliCtx.Context); err == nil {
+			useRegisterPlatformV2 = types.hasTerraformProviderVersionRegisterPlatformV2Mutation()
+		} else {
+			fmt.Println("Failed to check for presence of terraformProviderVersionRegisterPlatformV2Mutation ", err.Error())
+		}
 
 		fmt.Println("Retrieving release data from ", dir)
 		versionData, err := internal.BuildGoReleaserVersionData(dir)
@@ -161,6 +167,33 @@ func registerPlatform(ctx context.Context, dir string, versionID string, artifac
 	}
 
 	return nil
+}
+
+type mutationTypesQuery struct {
+	Schema struct {
+		MutationType struct {
+			Fields []mutationTypeField
+		}
+	} `graphql:"__schema"`
+}
+
+type mutationTypeField struct {
+	Name string
+}
+
+func (q mutationTypesQuery) hasTerraformProviderVersionRegisterPlatformV2Mutation() bool {
+	return slices.ContainsFunc(q.Schema.MutationType.Fields, func(field mutationTypeField) bool {
+		return field.Name == "terraformProviderVersionRegisterPlatformV2"
+	})
+}
+
+func mutationTypes(ctx context.Context) (mutationTypesQuery, error) {
+	query := mutationTypesQuery{}
+	err := authenticated.Client.Query(ctx, &query, nil)
+	if err != nil {
+		return mutationTypesQuery{}, err
+	}
+	return query, nil
 }
 
 func registerPlatformV2(ctx context.Context, dir string, versionID string, artifact *internal.GoReleaserArtifact) error {

--- a/internal/cmd/provider/flags.go
+++ b/internal/cmd/provider/flags.go
@@ -42,11 +42,6 @@ var flagProviderType = &cli.StringFlag{
 	Required: true,
 }
 
-var flagUseRegisterPlatformV2 = &cli.BoolFlag{
-	Name:  "use-register-platform-v2",
-	Usage: "Use register platform v2 mutation",
-}
-
 var flagProviderVersionProtocols = &cli.StringSliceFlag{
 	Name:  "protocols",
 	Usage: "Terraform plugin protocols supported by the provider",

--- a/internal/cmd/provider/provider.go
+++ b/internal/cmd/provider/provider.go
@@ -54,7 +54,6 @@ func Command() *cli.Command {
 					flagProviderVersionProtocols,
 					flagGoReleaserDir,
 					flagGPGKeyID,
-					flagUseRegisterPlatformV2,
 				},
 				Action:    createVersion(),
 				Before:    authenticated.Ensure,


### PR DESCRIPTION
Introspection is used to determine whether we want to use the registerPlatformV2 mutation or not.
Follow up of this PR https://github.com/spacelift-io/spacectl/pull/273