### PR TITLE
feat: allow spacectl usage in hooks

### DIFF
--- a/internal/cmd/stack/list.go
+++ b/internal/cmd/stack/list.go
@@ -162,7 +162,7 @@ func searchAllStacks(ctx context.Context, input structs.SearchInput) ([]stack, e
 			)
 		}
 
-		result, err := searchStacks(ctx, pageInput)
+		result, err := searchStacks[stack](ctx, pageInput)
 		if err != nil {
 			return nil, err
 		}
@@ -177,6 +177,24 @@ func searchAllStacks(ctx context.Context, input structs.SearchInput) ([]stack, e
 	}
 
 	return out, nil
+}
+
+type hasIDAndName interface {
+	GetID() string
+	GetName() string
+}
+
+type stackID struct {
+	ID   string `graphql:"id" json:"id,omitempty"`
+	Name string `graphql:"name" json:"name,omitempty"`
+}
+
+func (s stackID) GetID() string {
+	return s.ID
+}
+
+func (s stackID) GetName() string {
+	return s.Name
 }
 
 type stack struct {
@@ -236,4 +254,12 @@ type stack struct {
 		ID   string `graphql:"id" json:"id,omitempty"`
 		Name string `graphql:"name" json:"name,omitempty"`
 	} `graphql:"workerPool" json:"workerPool,omitempty"`
+}
+
+func (s stack) GetID() string {
+	return s.ID
+}
+
+func (s stack) GetName() string {
+	return s.Name
 }

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -33,7 +33,7 @@ func localPreview() cli.ActionFunc {
 			})
 		}
 
-		stack, err := getStack(cliCtx)
+		stack, err := getStack[stack](cliCtx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

Confirmed it works on preprod using custom worker:
Hooks:
- `echo "Testing whether machine api token works" > xyz`
- `spacectl stack environment mount --id tofuone file_from_ansible_hook xyz`
![image](https://github.com/user-attachments/assets/b9ec78ef-5b7d-4322-a9dc-02fb161a2f8a)
