### PR TITLE
Fix local-preview project-root-only flag.

### DIFF
--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -87,7 +87,7 @@ func localPreview() cli.ActionFunc {
 			ignoreFiles = append(ignoreFiles, ".gitignore")
 		}
 
-		matchFn, err := internal.GetIgnoreMatcherFn(ctx, nil, ignoreFiles)
+		matchFn, err := internal.GetIgnoreMatcherFn(ctx, packagePath, ignoreFiles)
 		if err != nil {
 			return fmt.Errorf("couldn't analyze .gitignore and .terraformignore files")
 		}


### PR DESCRIPTION
It seems 9274791e1066670d9b481c3e0f51feaa8d52d28f which added `.gitignore` support inadvertently removed packagePath from the call to `GetIgnoreMatcherFn`.

Fixes: #287 