### PR TITLE
feat: add headers to upload workspace

### DIFF
--- a/client/structs/string_map.go
+++ b/client/structs/string_map.go
@@ -1,0 +1,16 @@
+package structs
+
+type StringMap struct {
+	Entries []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"entries"`
+}
+
+func (m StringMap) StdMap() map[string]string {
+	res := make(map[string]string, len(m.Entries))
+	for _, entry := range m.Entries {
+		res[entry.Key] = entry.Value
+	}
+	return res
+}

--- a/internal/cmd/module/local_preview.go
+++ b/internal/cmd/module/local_preview.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mholt/archiver/v3"
 	"github.com/shurcooL/graphql"
+	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
@@ -37,7 +38,7 @@ func localPreview() cli.ActionFunc {
 			UploadLocalWorkspace struct {
 				ID            string            `graphql:"id"`
 				UploadURL     string            `graphql:"uploadUrl"`
-				UploadHeaders map[string]string `graphql:"uploadHeaders"`
+				UploadHeaders structs.StringMap `graphql:"uploadHeaders"`
 			} `graphql:"uploadLocalWorkspace(stack: $stack)"`
 		}
 
@@ -78,7 +79,7 @@ func localPreview() cli.ActionFunc {
 
 		fmt.Println("Uploading local workspace...")
 
-		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp, uploadMutation.UploadLocalWorkspace.UploadHeaders); err != nil {
+		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp, uploadMutation.UploadLocalWorkspace.UploadHeaders.StdMap()); err != nil {
 			return fmt.Errorf("couldn't upload archive: %w", err)
 		}
 

--- a/internal/cmd/module/local_preview.go
+++ b/internal/cmd/module/local_preview.go
@@ -35,8 +35,9 @@ func localPreview() cli.ActionFunc {
 
 		var uploadMutation struct {
 			UploadLocalWorkspace struct {
-				ID        string `graphql:"id"`
-				UploadURL string `graphql:"uploadUrl"`
+				ID            string            `graphql:"id"`
+				UploadURL     string            `graphql:"uploadUrl"`
+				UploadHeaders map[string]string `graphql:"uploadHeaders"`
 			} `graphql:"uploadLocalWorkspace(stack: $stack)"`
 		}
 
@@ -77,7 +78,7 @@ func localPreview() cli.ActionFunc {
 
 		fmt.Println("Uploading local workspace...")
 
-		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp); err != nil {
+		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp, uploadMutation.UploadLocalWorkspace.UploadHeaders); err != nil {
 			return fmt.Errorf("couldn't upload archive: %w", err)
 		}
 

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -67,8 +67,9 @@ func localPreview() cli.ActionFunc {
 
 		var uploadMutation struct {
 			UploadLocalWorkspace struct {
-				ID        string `graphql:"id"`
-				UploadURL string `graphql:"uploadUrl"`
+				ID            string            `graphql:"id"`
+				UploadURL     string            `graphql:"uploadUrl"`
+				UploadHeaders map[string]string `graphql:"uploadHeaders"`
 			} `graphql:"uploadLocalWorkspace(stack: $stack)"`
 		}
 
@@ -109,7 +110,7 @@ func localPreview() cli.ActionFunc {
 
 		fmt.Println("Uploading local workspace...")
 
-		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp); err != nil {
+		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp, uploadMutation.UploadLocalWorkspace.UploadHeaders); err != nil {
 			return fmt.Errorf("couldn't upload archive: %w", err)
 		}
 

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mholt/archiver/v3"
 	"github.com/shurcooL/graphql"
+	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
@@ -69,7 +70,7 @@ func localPreview() cli.ActionFunc {
 			UploadLocalWorkspace struct {
 				ID            string            `graphql:"id"`
 				UploadURL     string            `graphql:"uploadUrl"`
-				UploadHeaders map[string]string `graphql:"uploadHeaders"`
+				UploadHeaders structs.StringMap `graphql:"uploadHeaders"`
 			} `graphql:"uploadLocalWorkspace(stack: $stack)"`
 		}
 
@@ -110,7 +111,7 @@ func localPreview() cli.ActionFunc {
 
 		fmt.Println("Uploading local workspace...")
 
-		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp, uploadMutation.UploadLocalWorkspace.UploadHeaders); err != nil {
+		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp, uploadMutation.UploadLocalWorkspace.UploadHeaders.StdMap()); err != nil {
 			return fmt.Errorf("couldn't upload archive: %w", err)
 		}
 

--- a/internal/local_preview.go
+++ b/internal/local_preview.go
@@ -117,7 +117,7 @@ func UploadArchive(ctx context.Context, uploadURL, path string, uploadHeaders ma
 		return fmt.Errorf("couldn't upload workspace: %w", err)
 	}
 	defer response.Body.Close()
-	if code := response.StatusCode; code != http.StatusOK {
+	if code := response.StatusCode; code != http.StatusOK && code != http.StatusCreated {
 		return fmt.Errorf("unexpected response code when uploading workspace: %d", code)
 	}
 

--- a/internal/local_preview.go
+++ b/internal/local_preview.go
@@ -85,7 +85,7 @@ func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []
 }
 
 // UploadArchive uploads a tarball to the target endpoint and displays a fancy progress bar.
-func UploadArchive(ctx context.Context, uploadURL, path string) (err error) {
+func UploadArchive(ctx context.Context, uploadURL, path string, uploadHeaders map[string]string) (err error) {
 	stat, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("couldn't stat archive file: %w", err)
@@ -107,6 +107,10 @@ func UploadArchive(ctx context.Context, uploadURL, path string) (err error) {
 	}
 	req.ContentLength = stat.Size()
 	req = req.WithContext(ctx)
+
+	for k, v := range uploadHeaders {
+		req.Header.Set(k, v)
+	}
 
 	response, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Send upload headers with the upload local workspace. It's required for the azure provider, other providers will be noop