### PR TITLE
feat: use headers for tf version files upload

### DIFF
--- a/client/structs/string_map.go
+++ b/client/structs/string_map.go
@@ -1,5 +1,7 @@
 package structs
 
+import "net/http"
+
 type StringMap struct {
 	Entries []struct {
 		Key   string `json:"key"`
@@ -11,6 +13,13 @@ func (m StringMap) StdMap() map[string]string {
 	res := make(map[string]string, len(m.Entries))
 	for _, entry := range m.Entries {
 		res[entry.Key] = entry.Value
+	}
+	return res
+}
+func (m StringMap) HTTPHeaders() http.Header {
+	res := make(http.Header, len(m.Entries))
+	for _, entry := range m.Entries {
+		res.Set(entry.Key, entry.Value)
 	}
 	return res
 }

--- a/internal/cmd/provider/create_version.go
+++ b/internal/cmd/provider/create_version.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/client/structs"
 )
 
 func createVersion() cli.ActionFunc {
@@ -57,9 +59,12 @@ func createVersion() cli.ActionFunc {
 
 		var createMutation struct {
 			CreateTerraformProviderVersion struct {
-				SHA256SumsUploadURL    string `graphql:"sha256SumsUploadURL"`
-				SHA256SumsSigUploadURL string `graphql:"sha256SumsSigUploadURL"`
-				Version                struct {
+				SHA256SumsUploadURL     string            `graphql:"sha256SumsUploadURL"`
+				SHA256SumsUploadHeaders structs.StringMap `graphql:"sha256SumsUploadHeaders"`
+
+				SHA256SumsSigUploadURL     string            `graphql:"sha256SumsSigUploadURL"`
+				SHA256SumsSigUploadHeaders structs.StringMap `graphql:"sha256SumsSigUploadHeaders"`
+				Version                    struct {
 					ID string `graphql:"id"`
 				} `graphql:"version"`
 			} `graphql:"terraformProviderVersionCreate(provider: $provider, input: $input)"`
@@ -81,12 +86,12 @@ func createVersion() cli.ActionFunc {
 		}
 
 		fmt.Println("Uploading the checksums file")
-		if err := checksumsFile.Upload(cliCtx.Context, dir, createMutation.CreateTerraformProviderVersion.SHA256SumsUploadURL, checksumsFile.AWSMetadataHeaders()); err != nil {
+		if err := checksumsFile.Upload(cliCtx.Context, dir, createMutation.CreateTerraformProviderVersion.SHA256SumsUploadURL, createMutation.CreateTerraformProviderVersion.SHA256SumsUploadHeaders.HTTPHeaders()); err != nil {
 			return errors.Wrap(err, "could not upload checksums file")
 		}
 
 		fmt.Println("Uploading the signatures file")
-		if err := signatureFile.Upload(cliCtx.Context, dir, createMutation.CreateTerraformProviderVersion.SHA256SumsSigUploadURL, signatureFile.AWSMetadataHeaders()); err != nil {
+		if err := signatureFile.Upload(cliCtx.Context, dir, createMutation.CreateTerraformProviderVersion.SHA256SumsSigUploadURL, createMutation.CreateTerraformProviderVersion.SHA256SumsSigUploadHeaders.HTTPHeaders()); err != nil {
 			return errors.Wrap(err, "could not upload signature file")
 		}
 

--- a/internal/cmd/provider/create_version.go
+++ b/internal/cmd/provider/create_version.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
 	"github.com/urfave/cli/v2"
-
-	"github.com/spacelift-io/spacectl/client/structs"
 )
 
 func createVersion() cli.ActionFunc {


### PR DESCRIPTION
Send upload headers with the file upload. It's required for the azure provider, other providers will be noop