### PR TITLE
Do not recurse into ignored directories.

### DIFF
--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mholt/archiver/v3"
 	"github.com/shurcooL/graphql"
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
@@ -94,12 +93,9 @@ func localPreview() cli.ActionFunc {
 			return fmt.Errorf("couldn't analyze .gitignore and .terraformignore files")
 		}
 
-		tgz := *archiver.DefaultTarGz
-		tgz.ForceArchiveImplicitTopLevelFolder = true
-		tgz.MatchFn = matchFn
-
-		if err := tgz.Archive([]string{"."}, fp); err != nil {
-			return fmt.Errorf("couldn't archive local directory: %w", err)
+		err = internal.CreateArchive(ctx, ".", fp, matchFn)
+		if err != nil {
+			return fmt.Errorf("CreateArchive: %w", err)
 		}
 
 		if cliCtx.Bool(flagNoUpload.Name) {

--- a/internal/local_preview.go
+++ b/internal/local_preview.go
@@ -3,12 +3,15 @@ package internal
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/cheggaaa/pb/v3"
+	"github.com/mholt/archiver/v3"
 	ignore "github.com/sabhiram/go-gitignore"
 )
 
@@ -46,10 +49,12 @@ func MoveToRepositoryRoot() error {
 	}
 }
 
+type IgnoreMatcherFn func(filePath string) bool
+
 // GetIgnoreMatcherFn creates an ignore-matcher for archiving purposes
 // This function respects gitignore and terraformignore, and
 // optionally if a projectRoot is provided it only include files from this root
-func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []string) (func(filePath string) bool, error) {
+func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []string) (IgnoreMatcherFn, error) {
 	ignoreList := make([]*ignore.GitIgnore, 0)
 	for _, f := range ignoreFiles {
 		ignoreFile, err := ignore.CompileIgnoreFile(f)
@@ -58,6 +63,16 @@ func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []
 		}
 
 		ignoreList = append(ignoreList, ignoreFile)
+	}
+
+	projectRootPrefixes := make(map[string]struct{})
+	if projectRoot != nil {
+		rootPrefix := "."
+		projectRootPrefixes[rootPrefix] = struct{}{}
+		for _, part := range strings.Split(*projectRoot, string(os.PathSeparator)) {
+			rootPrefix = filepath.Join(rootPrefix, part)
+			projectRootPrefixes[rootPrefix] = struct{}{}
+		}
 	}
 
 	customignore := ignore.CompileIgnoreLines(".git", ".terraform")
@@ -73,6 +88,10 @@ func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []
 		}
 
 		if projectRoot != nil {
+			// We must include all path prefixes of the projectRoot as well.
+			if _, ok := projectRootPrefixes[filePath]; ok {
+				return true
+			}
 			// ensure the root only matches the directory and not all other files
 			root := strings.TrimSuffix(*projectRoot, "/") + "/"
 			if !strings.HasPrefix(filePath, root) {
@@ -82,6 +101,82 @@ func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []
 
 		return true
 	}, nil
+}
+
+// Create a tar.gz of the contents of src at dest. The contents of dest are
+// filtered by the matchFn. To speed up processing of large ignored directories
+// we also short circuit the file system walk if a directory is ignored.
+func CreateArchive(ctx context.Context, src, dest string, matchFn IgnoreMatcherFn) error {
+	if !strings.HasSuffix(dest, ".tar.gz") {
+		fmt.Errorf(".tar.gz extention required: %s", dest)
+	}
+
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return fmt.Errorf("stat %s, %w", src, err)
+	}
+
+	tgz := *archiver.DefaultTarGz
+
+	destDir := filepath.Dir(dest)
+	err = os.MkdirAll(destDir, 0755)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("%s: mkdir %w", destDir, err)
+		}
+	}
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", dest, err)
+	}
+	defer out.Close()
+
+	err = tgz.Create(out)
+	if err != nil {
+		return fmt.Errorf("creating tgz: %w", err)
+	}
+	defer tgz.Close()
+
+	base := filepath.Base(dest)
+	prefixInArchive := strings.TrimSuffix(base, ".tar.gz")
+
+	return filepath.Walk(src, func(fpath string, info os.FileInfo, err error) error {
+		if !matchFn(fpath) {
+			if info.Mode().IsDir() {
+				return filepath.SkipDir
+			}
+			if info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+				return nil
+			}
+		}
+		nameInArchive, err := archiver.NameInArchive(srcInfo, src, fpath)
+		if err != nil {
+			return fmt.Errorf("NameInArchive %s: %w", fpath, err)
+		}
+		fullNameInArchive := path.Join(prefixInArchive, nameInArchive)
+		var file io.ReadCloser
+		if info.Mode().IsRegular() {
+			file, err = os.Open(fpath)
+			if err != nil {
+				return fmt.Errorf("%s: open: %w", fpath, err)
+			}
+			defer file.Close()
+		}
+		err = tgz.Write(archiver.File{
+			FileInfo: archiver.FileInfo{
+				FileInfo:   info,
+				CustomName: fullNameInArchive,
+			},
+			FullFilePath: fpath,
+			ReadCloser:   file,
+		})
+		if err != nil {
+			return fmt.Errorf("%s: writing: %w", fpath, err)
+		}
+
+		return nil
+	})
 }
 
 // UploadArchive uploads a tarball to the target endpoint and displays a fancy progress bar.


### PR DESCRIPTION
When generating the tar.gz for local previews can skip recursively processing them. This potentially saves a lot of processing time by removing the stat calls to the files contained in them. This tends to be the case for node_modules and other commonly ignored paths.

On my internal git repo running on macos this results in a -82% change to the time to generate the tar.tz.
```
$ time spacectl stack local-preview --id test  --no-upload
151.33 secs

$ time ~/src/spacectl/spacectl stack local-preview --id test  --no-upload
26.32 secs
```

I also checked if the same files were included in both tar.gz files.
```
$ tar -tf ~/old.tar.gz | sed 's|[^/]*||' | shasum
82510ad099d3eb9e3c1bba906b8b8dff00c802aa  -

$ tar -tf ~/new.tar.gz | sed 's|[^/]*||' | shasum
82510ad099d3eb9e3c1bba906b8b8dff00c802aa  -
```

Fixes: #289 