### PR TITLE
Add versioning support to spacectl commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,177 @@
+# spacectl Contributing Guide
+
+In this guide you will get an overview of the contribution workflow from opening an issue, creating a pull request, to having it reviewed, merged and deployed.
+
+We welcome all contributions, no matter the size or complexity. Every contribution helps and is appreciated.
+
+The following is a set of guidelines for contributing to spacectl. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## Reporting an Issue
+
+If you spot a problem with spacectl [search if an issue already exists](https://github.com/spacelift-io/spacectl/issues). If a related issue doesn't exist, please open a new issue using [the issue form](https://github.com/spacelift-io/user-documentation/issues/new).
+
+## Making Changes
+
+spacectl is written in Go, and uses the [Spacelift GraphQL API](https://docs.spacelift.io/integrations/api) to interact with Spacelift. To make changes to spacectl you will need at least the following:
+
+- A working copy of [Go](https://go.dev/). Check [go.mod](./go.mod) to see what is the current version used by this project.
+- A Spacelift account you can use for testing. Please go to <https://spacelift.io/free-trial> to create a free account if you don't already have one.
+
+### Command versioning
+
+spacectl supports working with both SaaS and Self-Hosted instances of Spacelift. Because of this we need to have a mechanism in place for ensuring API compatibility with different versions. To support this, each command can have multiple different implementations, which work with different versions of Spacelift.
+
+#### Defining a command
+
+Commands are defined using the `cmd.Command` struct like in the following example:
+
+```go
+{
+	Category: "Run local preview",
+	Name:     "local-preview",
+	Usage:    "Start a preview (proposed run) based on the current project. Respects .gitignore and .terraformignore.",
+	Versions: []cmd.VersionedCommand{
+		{
+			EarliestVersion: cmd.SupportedVersionAll,
+			Command: &cli.Command{
+				Flags: []cli.Flag{
+					flagStackID,
+					// ... other flags
+				},
+				Action:    localPreview(false),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+		},
+		{
+			EarliestVersion: cmd.SupportedVersion("2.5.0"),
+			Command: &cli.Command{
+				Flags: []cli.Flag{
+					flagStackID,
+					// ... other flags
+				},
+				Action:    localPreview(true),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+		},
+	},
+},
+```
+
+In the example above, we are defining a new subcommand for the `stack` command called `local-preview`. There are two versions of the command: one that works with any version of Spacelift, and another that only works with versions 2.5.0 and above.
+
+The `EarliestVersion` field can have the following values:
+
+- `SupportedVersionAll` - indicating it can be used with any version of Spacelift.
+- `SupportedVersionLatest` - indicating it can only be used with Spacelift's SaaS product, but will be available in the next Self-Hosted version.
+- A specific version number, for example `2.5.0` - indicating that it can be used with Spacelift SaaS, or a Self-Hosted instance running v2.5.0 or above.
+
+#### Adding a new command
+
+When adding a new command the safest thing to do is set the `EarliestVersion` to `SupportedVersionLatest`. This means that it will only be available to Self-Hosted installations after the next release of Self-Hosted.
+
+The exception to this is if you are certain that the API your command needs is available in all supported Self-Hosted versions, in which case you can use `SupportedVersionAll`.
+
+#### Making changes to existing commands
+
+When making changes to existing spacectl commands, if your change relies on a GraphQL API feature that isn't currently released to all supported versions of Self-Hosted, please add a new version of the command with the `EarliestVersion` set to `SupportedVersionLatest`.
+
+## Submitting Changes
+
+Once you are happy with your changes, just open a pull request.
+
+By submitting a pull request for this project, you agree to license your contribution under the [MIT license](./LICENSE) to Spacelift.
+
+## Releasing
+
+### Self-Hosted Releases
+
+If a new version of Self-Hosted has been released, and you want to enable functionality that was previously waiting for the changes to become available in the Self-Hosted GraphQL API, find any references to `cmd.SupportedVersionLatest`, and replace them with the new Self-Hosted version.
+
+For example, if we have the following command definition:
+
+```go
+{
+	Category: "Run local preview",
+	Name:     "local-preview",
+	Usage:    "Start a preview (proposed run) based on the current project. Respects .gitignore and .terraformignore.",
+	Versions: []cmd.VersionedCommand{
+		{
+			EarliestVersion: cmd.SupportedVersionAll,
+			Command: &cli.Command{
+				Flags: []cli.Flag{
+					flagStackID,
+					// ... other flags
+				},
+				Action:    localPreview(false),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+		},
+		{
+			EarliestVersion: cmd.SupportedVersionLatest,
+			Command: &cli.Command{
+				Flags: []cli.Flag{
+					flagStackID,
+					// ... other flags
+				},
+				Action:    localPreview(true),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+		},
+	},
+},
+```
+
+And we have just released version 2.5.0 of Self-Hosted with support for the new API functionality needed by the command, we would change it to the following:
+
+```go
+{
+	Category: "Run local preview",
+	Name:     "local-preview",
+	Usage:    "Start a preview (proposed run) based on the current project. Respects .gitignore and .terraformignore.",
+	Versions: []cmd.VersionedCommand{
+		{
+			EarliestVersion: cmd.SupportedVersionAll,
+			Command: &cli.Command{
+				Flags: []cli.Flag{
+					flagStackID,
+					// ... other flags
+				},
+				Action:    localPreview(false),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+		},
+		{
+			EarliestVersion: cmd.SupportedVersion("2.5.0"), // <-- Latest replaced by 2.5.0.
+			Command: &cli.Command{
+				Flags: []cli.Flag{
+					flagStackID,
+					// ... other flags
+				},
+				Action:    localPreview(true),
+				Before:    authenticated.Ensure,
+				ArgsUsage: cmd.EmptyArgsUsage,
+			},
+		},
+	},
+},
+```
+
+### Releasing spacectl
+
+To release a new version of spacectl, tag the repo and then push that tag. For example:
+
+```shell
+git checkout main
+git pull
+git tag -a v0.24.2 -m"Releasing v0.24.2"
+git push origin v0.24.2
+```
+
+After the tag is pushed, the [release](.github/workflows/release.yml) workflow will trigger and will automatically publish a new GitHub release.
+
+Once the [release](.github/workflows/release.yml) workflow is done, go to the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository and submit a pull request for the release version.

--- a/README.md
+++ b/README.md
@@ -269,17 +269,6 @@ By default the login process is interactive, however, if that does not fit your 
 
 You can switch between account profiles by using `spacectl profile select ${MY_ALIAS}`. What this does behind the scenes is point `${HOME}/.spacelift/current` to the new location. You can also delete stored credetials for a given profile by using the `spacectl profile logout ${MY_ALIAS}` command.
 
-## Releasing
+## Contributing
 
-To release a new version of spacectl, tag the repo and then push that tag. For example:
-
-```shell
-git checkout main
-git pull
-git tag -a v0.24.2 -m"Releasing v0.24.2"
-git push origin v0.24.2
-```
-
-After the tag is pushed, the [release](.github/workflows/release.yml) workflow will trigger and will automatically publish a new GitHub release.
-
-Once the [release](.github/workflows/release.yml) workflow is done, go to the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository and submit a pull request for the release version.
+For information about how to contribute to the development of spacectl, please see our [CONTRIBUTING.md](./CONTRIBUTING.md) file.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/spacelift-io/spacectl
 go 1.22
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/ProtonMail/gopenpgp/v2 v2.7.5
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.6
@@ -19,6 +20,7 @@ require (
 	github.com/pterm/pterm v0.12.79
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466
+	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.3
 	golang.org/x/oauth2 v0.22.0
 	golang.org/x/sync v0.10.0
@@ -42,6 +44,7 @@ require (
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fatih/color v1.15.0 // indirect
@@ -61,6 +64,7 @@ require (
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/nwaples/rardecode v1.0.0 // indirect
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ulikunitz/xz v0.5.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/MarvinJWendt/testza v0.3.0/go.mod h1:eFcL4I0idjtIx8P9C6KkAuLgATNKpX4/
 github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYewEjXsvsVUPbE=
 github.com/MarvinJWendt/testza v0.5.2 h1:53KDo64C1z/h/d/stCYCPY69bt/OSwjq5KpFNwi+zB4=
 github.com/MarvinJWendt/testza v0.5.2/go.mod h1:xu53QFE5sCdjtMCKk8YMQ2MnymimEctc4n3EjyIYvEY=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95 h1:KLq8BE0KwCL+mmXnjLWEAOYO+2l2AE4YMmqG1ZpZHBs=
 github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f h1:tCbYj7/299ekTTXpdwKYF8eBlsYsDVoggDAuAjoK66k=
@@ -168,8 +170,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/urfave/cli/v2 v2.27.3 h1:/POWahRmdh7uztQ3CYnaDddk0Rm90PyOgIxgW2rr41M=

--- a/internal/cmd/audittrail/audit_trail.go
+++ b/internal/cmd/audittrail/audit_trail.go
@@ -7,26 +7,40 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
-func Command() *cli.Command {
-	return &cli.Command{
+// Command returns the audit-trail command subtree.
+func Command() cmd.Command {
+	return cmd.Command{
 		Name:  "audit-trail",
 		Usage: "Manage a Spacelift audit trail entries",
-		Subcommands: []*cli.Command{
+		Versions: []cmd.VersionedCommand{
+			{
+				EarliestVersion: cmd.SupportedVersionAll,
+				Command:         &cli.Command{},
+			},
+		},
+		Subcommands: []cmd.Command{
 			{
 				Name:  "list",
 				Usage: "List the audit trail entries you have access to",
-				Flags: []cli.Flag{
-					cmd.FlagOutputFormat,
-					cmd.FlagNoColor,
-					cmd.FlagLimit,
-					cmd.FlagSearch,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagOutputFormat,
+								cmd.FlagNoColor,
+								cmd.FlagLimit,
+								cmd.FlagSearch,
+							},
+							Action: listAuditTrails(),
+							Before: cmd.PerformAllBefore(
+								cmd.HandleNoColor,
+								authenticated.Ensure,
+							),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action: listAuditTrails(),
-				Before: cmd.PerformAllBefore(
-					cmd.HandleNoColor,
-					authenticated.Ensure,
-				),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 		},
 	}

--- a/internal/cmd/blueprint/blueprint.go
+++ b/internal/cmd/blueprint/blueprint.go
@@ -10,53 +10,80 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
-// Command encapsulates the blueprintNode command subtree.
-func Command() *cli.Command {
-	return &cli.Command{
+// Command returns the blueprint command subtree.
+func Command() cmd.Command {
+	return cmd.Command{
 		Name:  "blueprint",
 		Usage: "Manage a Spacelift blueprints",
-		Subcommands: []*cli.Command{
+		Versions: []cmd.VersionedCommand{
+			{
+				EarliestVersion: cmd.SupportedVersionAll,
+				Command:         &cli.Command{},
+			},
+		},
+		Subcommands: []cmd.Command{
 			{
 				Name:  "list",
 				Usage: "List the blueprints you have access to",
-				Flags: []cli.Flag{
-					cmd.FlagShowLabels,
-					cmd.FlagOutputFormat,
-					cmd.FlagNoColor,
-					cmd.FlagLimit,
-					cmd.FlagSearch,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagShowLabels,
+								cmd.FlagOutputFormat,
+								cmd.FlagNoColor,
+								cmd.FlagLimit,
+								cmd.FlagSearch,
+							},
+							Action: listBlueprints(),
+							Before: cmd.PerformAllBefore(
+								cmd.HandleNoColor,
+								authenticated.Ensure,
+								validateLimit,
+								validateSearch,
+							),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action: listBlueprints(),
-				Before: cmd.PerformAllBefore(
-					cmd.HandleNoColor,
-					authenticated.Ensure,
-					validateLimit,
-					validateSearch,
-				),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "show",
 				Usage: "Shows detailed information about a specific blueprint",
-				Flags: []cli.Flag{
-					flagRequiredBlueprintID,
-					cmd.FlagOutputFormat,
-					cmd.FlagNoColor,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagRequiredBlueprintID,
+								cmd.FlagOutputFormat,
+								cmd.FlagNoColor,
+							},
+							Action:    (&showCommand{}).show,
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    (&showCommand{}).show,
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "deploy",
 				Usage: "Deploy a stack from the blueprint",
-				Flags: []cli.Flag{
-					flagRequiredBlueprintID,
-					cmd.FlagNoColor,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagRequiredBlueprintID,
+								cmd.FlagNoColor,
+							},
+							Action:    (&deployCommand{}).deploy,
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    (&deployCommand{}).deploy,
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 		},
 	}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"slices"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/urfave/cli/v2"
+
+	spslices "github.com/spacelift-io/spacectl/internal/slices"
+)
+
+// SupportedVersion is used to indicate what versions of Spacelift certain spacectl commands are
+// compatible with.
+type SupportedVersion string
+
+const (
+	// SupportedVersionAll indicates that the command is available for all versions of Spacelift.
+	SupportedVersionAll = "all"
+
+	// SupportedVersionLatest indicates that the command is supported for SaaS, and will be supported
+	// by Self-Hosted after the next Self-Hosted release.
+	SupportedVersionLatest = "latest"
+)
+
+type Command struct {
+	Name     string
+	Usage    string
+	Category string
+
+	// Versions defines the available versions for the command.
+	Versions []VersionedCommand
+
+	// Subcommands gets the list of subcommands that support the specified version.
+	Subcommands []Command
+}
+
+type VersionedCommand struct {
+	// EarliestVersion indicates that the command needs at least the indicated Self-Hosted version
+	// in order to work.
+	//
+	// - SupportedVersionAll - indicates that the command can be used for any Spacelift version (both SaaS and Self-Hosted).
+	// - SupportedVersionLatest - indicates that the command can be used with SaaS, but will not be available to Self-Hosted until the next release.
+	// - 1.2.3, 2.5.0, etc - indicates that the command can be used with SaaS, or a Self-Hosted version equal to or higher than the specified version.
+	EarliestVersion SupportedVersion
+
+	// The CLI command definition.
+	Command *cli.Command
+}
+
+type SpaceliftInstanceType uint
+
+const (
+	// SpaceliftInstanceTypeUnknown indicates that we don't know what type of instance spacectl
+	// is being used against. This can happen before a profile has been created or if the credentials
+	// have expired.
+	SpaceliftInstanceTypeUnknown SpaceliftInstanceType = iota
+
+	// SpaceliftInstanceTypeSaaS indicates we're talking to Spacelift SaaS.
+	SpaceliftInstanceTypeSaaS
+
+	// SpaceliftInstanceTypeSelfHosted indicates we're talking to a Self-Hosted instance.
+	SpaceliftInstanceTypeSelfHosted
+)
+
+type SpaceliftInstanceVersion struct {
+	// InstanceType defines the type of instance we're connecting to.
+	InstanceType SpaceliftInstanceType
+
+	// Version indicates the Self-Hosted version we are communicating with. It will be nil for SaaS.
+	Version *semver.Version
+}
+
+// SimplifiedVersion returns the version (if set) without the prerelease or metadata parts.
+func (v SpaceliftInstanceVersion) SimplifiedVersion() *semver.Version {
+	if v.Version == nil {
+		return nil
+	}
+
+	return semver.New(v.Version.Major(), v.Version.Minor(), v.Version.Patch(), "", "")
+}
+
+// String returns a string representation of the instance version.
+func (v SpaceliftInstanceVersion) String() string {
+	switch v.InstanceType {
+	case SpaceliftInstanceTypeSaaS:
+		return "SaaS"
+	case SpaceliftInstanceTypeUnknown:
+		return "Unknown"
+	}
+
+	if v.Version != nil {
+		return "Self-Hosted " + v.Version.String()
+	}
+
+	return "Self-Hosted"
+}
+
+// ResolveCommands finds the set of command versions from allCommands and their subcommands that
+// are available based on the specified Spacelift instance version.
+func ResolveCommands(instanceVersion SpaceliftInstanceVersion, allCommands []Command) []*cli.Command {
+	var availableCommands []*cli.Command
+	for _, command := range allCommands {
+		latestVersion := command.FindLatestSupportedVersion(instanceVersion)
+		if latestVersion != nil {
+			latestVersion.Command.Name = command.Name
+			latestVersion.Command.Usage = command.Usage
+			latestVersion.Command.Category = command.Category
+
+			// Recursively resolve subcommands
+			latestVersion.Command.Subcommands = resolveSubcommands(instanceVersion, command.Subcommands)
+
+			availableCommands = append(availableCommands, latestVersion.Command)
+		}
+	}
+
+	return availableCommands
+}
+
+// resolveSubcommands recursively processes command subcommands at any level of nesting
+func resolveSubcommands(instanceVersion SpaceliftInstanceVersion, subcommands []Command) []*cli.Command {
+	var resolvedSubcommands []*cli.Command
+
+	for _, subcommand := range subcommands {
+		latestVersion := subcommand.FindLatestSupportedVersion(instanceVersion)
+		if latestVersion != nil {
+			latestVersion.Command.Name = subcommand.Name
+			latestVersion.Command.Usage = subcommand.Usage
+			latestVersion.Command.Category = subcommand.Category
+
+			// Recursively process this subcommand's subcommands
+			if len(subcommand.Subcommands) > 0 {
+				latestVersion.Command.Subcommands = resolveSubcommands(instanceVersion, subcommand.Subcommands)
+			}
+
+			resolvedSubcommands = append(resolvedSubcommands, latestVersion.Command)
+		}
+	}
+
+	return resolvedSubcommands
+}
+
+// FindLatestSupportedVersion finds the latest supported version of the specified command. It returns
+// nil if no version of the command is supported by the Spacelift instance.
+func (c Command) FindLatestSupportedVersion(instanceVersion SpaceliftInstanceVersion) *VersionedCommand {
+	// // Get potential list of commands:
+	// //   - If not SaaS, we can remove the "latest" version.
+	// //   - If self-hosted we can remove any versions that are not supported by the instance.
+	// // Sort the commands into order of preference: "latest", specific versions, then "all".
+	// // Return the first command, or nil if none is supported.
+	availableCommands := c.Versions
+	if instanceVersion.InstanceType != SpaceliftInstanceTypeSaaS {
+		availableCommands = spslices.Filter(availableCommands, func(v VersionedCommand) bool {
+			if instanceVersion.InstanceType == SpaceliftInstanceTypeUnknown && v.EarliestVersion != SupportedVersionAll {
+				// If we don't know the type / version of the instance, we can only return commands available
+				// to any version of Spacelift.
+				return false
+			}
+
+			if v.EarliestVersion == SupportedVersionLatest {
+				// If the version is marked as "latest", it won't be available yet in a Self-Hosted
+				// instance because a version of Self-Hosted supporting the command hasn't been released
+				// yet.
+				return false
+			}
+
+			if v.EarliestVersion == SupportedVersionAll {
+				// This command is supported for all versions of Spacelift.
+				return true
+			}
+
+			// We're assuming that because the command versions are defined statically in the code,
+			// the version should always parse.
+			version := semver.MustParse(string(v.EarliestVersion))
+
+			// If the command only supports certain Self-Hosted instances, only include it if
+			// the Spacelift instance we're connecting to is running at least the earliest version
+			// supported by the command.
+			return instanceVersion.SimplifiedVersion().GreaterThanEqual(version)
+		})
+	}
+
+	if len(availableCommands) == 0 {
+		return nil
+	}
+
+	slices.SortStableFunc(availableCommands, func(a, b VersionedCommand) int {
+		if a.EarliestVersion == b.EarliestVersion {
+			return 0
+		}
+
+		if a.EarliestVersion == SupportedVersionLatest {
+			return -1
+		}
+
+		if b.EarliestVersion == SupportedVersionLatest {
+			return 1
+		}
+
+		if a.EarliestVersion == SupportedVersionAll {
+			return 1
+		}
+
+		if b.EarliestVersion == SupportedVersionAll {
+			return -1
+		}
+
+		aVersion := semver.MustParse(string(a.EarliestVersion))
+		bVersion := semver.MustParse(string(b.EarliestVersion))
+
+		// Otherwise we sort in semver order with the latest version coming first.
+		return bVersion.Compare(aVersion)
+	})
+
+	return &availableCommands[0]
+}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,0 +1,242 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/spacelift-io/spacectl/internal/cmd"
+	"github.com/spacelift-io/spacectl/internal/nullable"
+)
+
+type CommandTests struct {
+	suite.Suite
+}
+
+func Test_Command(t *testing.T) {
+	suite.Run(t, new(CommandTests))
+}
+
+func (t *CommandTests) Test_FindLatestSupportedVersion_SaaS() {
+	type testCase struct {
+		versions        []cmd.VersionedCommand
+		expectedVersion cmd.SupportedVersion
+	}
+
+	testCases := map[string]testCase{
+		"only latest": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			expectedVersion: cmd.SupportedVersionLatest,
+		},
+		"latest and all": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			expectedVersion: cmd.SupportedVersionLatest,
+		},
+		"latest and specific versions": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersion("1.2.0")},
+				{EarliestVersion: cmd.SupportedVersion("1.5.0")},
+				{EarliestVersion: cmd.SupportedVersion("2.3.3")},
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			expectedVersion: cmd.SupportedVersionLatest,
+		},
+		"specific versions": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersion("1.2.0")},
+				{EarliestVersion: cmd.SupportedVersion("1.5.0")},
+				{EarliestVersion: cmd.SupportedVersion("2.3.3")},
+			},
+			expectedVersion: cmd.SupportedVersion("2.3.3"),
+		},
+		"only all": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+			},
+			expectedVersion: cmd.SupportedVersionAll,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func() {
+			command := cmd.Command{
+				Versions: testCase.versions,
+			}
+
+			supportedVersion := command.FindLatestSupportedVersion(cmd.SpaceliftInstanceVersion{
+				InstanceType: cmd.SpaceliftInstanceTypeSaaS,
+			})
+
+			t.Require().NotNil(supportedVersion)
+			t.Equal(testCase.expectedVersion, supportedVersion.EarliestVersion)
+		})
+	}
+}
+
+func (t *CommandTests) Test_FindLatestSupportedVersion_Unknown() {
+	type testCase struct {
+		versions        []cmd.VersionedCommand
+		expectedVersion *cmd.SupportedVersion
+	}
+
+	testCases := map[string]testCase{
+		"only latest": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			expectedVersion: nil,
+		},
+		"latest and all": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			expectedVersion: nullable.OfValue[cmd.SupportedVersion](cmd.SupportedVersionAll),
+		},
+		"latest and specific versions": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersion("1.2.0")},
+				{EarliestVersion: cmd.SupportedVersion("1.5.0")},
+				{EarliestVersion: cmd.SupportedVersion("2.3.3")},
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			expectedVersion: nullable.OfValue[cmd.SupportedVersion](cmd.SupportedVersionAll),
+		},
+		"specific versions": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersion("1.2.0")},
+				{EarliestVersion: cmd.SupportedVersion("1.5.0")},
+				{EarliestVersion: cmd.SupportedVersion("2.3.3")},
+			},
+			expectedVersion: nullable.OfValue[cmd.SupportedVersion](cmd.SupportedVersionAll),
+		},
+		"only all": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+			},
+			expectedVersion: nullable.OfValue[cmd.SupportedVersion](cmd.SupportedVersionAll),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func() {
+			command := cmd.Command{
+				Versions: testCase.versions,
+			}
+
+			supportedVersion := command.FindLatestSupportedVersion(cmd.SpaceliftInstanceVersion{
+				InstanceType: cmd.SpaceliftInstanceTypeUnknown,
+			})
+
+			if testCase.expectedVersion != nil {
+				t.Require().NotNil(supportedVersion)
+				t.Equal(*testCase.expectedVersion, supportedVersion.EarliestVersion)
+			} else {
+				t.Nil(supportedVersion)
+			}
+		})
+	}
+}
+
+func (t *CommandTests) Test_FindLatestSupportedVersion_SelfHosted() {
+	type testCase struct {
+		versions          []cmd.VersionedCommand
+		selfHostedVersion *semver.Version
+		expectedVersion   *cmd.SupportedVersion
+	}
+
+	testCases := map[string]testCase{
+		"only latest": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			selfHostedVersion: semver.MustParse("1.2.0"),
+			expectedVersion:   nil,
+		},
+		"latest and all": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			selfHostedVersion: semver.MustParse("1.2.0"),
+			expectedVersion:   nullable.OfValue[cmd.SupportedVersion](cmd.SupportedVersionAll),
+		},
+		"latest and specific versions": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersion("1.2.0")},
+				{EarliestVersion: cmd.SupportedVersion("1.5.0")},
+				{EarliestVersion: cmd.SupportedVersion("2.3.3")},
+				{EarliestVersion: cmd.SupportedVersionLatest},
+			},
+			selfHostedVersion: semver.MustParse("1.5.3"),
+			expectedVersion:   nullable.OfValue(cmd.SupportedVersion("1.5.0")),
+		},
+		"specific versions with version match": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersion("1.2.0")},
+				{EarliestVersion: cmd.SupportedVersion("1.5.0")},
+				{EarliestVersion: cmd.SupportedVersion("2.3.3")},
+			},
+			selfHostedVersion: semver.MustParse("1.5.3"),
+			expectedVersion:   nullable.OfValue(cmd.SupportedVersion("1.5.0")),
+		},
+		"specific versions with no version match": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersion("1.2.0")},
+				{EarliestVersion: cmd.SupportedVersion("1.5.0")},
+				{EarliestVersion: cmd.SupportedVersion("2.3.3")},
+			},
+			selfHostedVersion: semver.MustParse("1.1.3"),
+			expectedVersion:   nullable.OfValue[cmd.SupportedVersion](cmd.SupportedVersionAll),
+		},
+		"ignores prerelease information in version number": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+				{EarliestVersion: cmd.SupportedVersion("1.2.0")},
+				{EarliestVersion: cmd.SupportedVersion("3.0.0")},
+			},
+			selfHostedVersion: semver.MustParse("3.0.0-alpha.2"),
+			expectedVersion:   nullable.OfValue(cmd.SupportedVersion("3.0.0")),
+		},
+		"only all": {
+			versions: []cmd.VersionedCommand{
+				{EarliestVersion: cmd.SupportedVersionAll},
+			},
+			selfHostedVersion: semver.MustParse("1.1.3"),
+			expectedVersion:   nullable.OfValue[cmd.SupportedVersion](cmd.SupportedVersionAll),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func() {
+			command := cmd.Command{
+				Versions: testCase.versions,
+			}
+
+			supportedVersion := command.FindLatestSupportedVersion(cmd.SpaceliftInstanceVersion{
+				InstanceType: cmd.SpaceliftInstanceTypeSelfHosted,
+				Version:      testCase.selfHostedVersion,
+			})
+
+			if testCase.expectedVersion != nil {
+				t.Require().NotNil(supportedVersion)
+				t.Equal(*testCase.expectedVersion, supportedVersion.EarliestVersion)
+			} else {
+				t.Nil(supportedVersion)
+			}
+		})
+	}
+}

--- a/internal/cmd/module/module.go
+++ b/internal/cmd/module/module.go
@@ -7,77 +7,133 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
-// Command encapsulates the module command subtree.
-func Command() *cli.Command {
-	return &cli.Command{
+func Command() cmd.Command {
+	return cmd.Command{
 		Name:  "module",
 		Usage: "Manage a Spacelift module",
-		Subcommands: []*cli.Command{
+		Versions: []cmd.VersionedCommand{
+			{
+				EarliestVersion: cmd.SupportedVersionAll,
+				Command:         &cli.Command{},
+			},
+		},
+		Subcommands: []cmd.Command{
 			{
 				Category: "Module management",
 				Name:     "create-version",
 				Usage:    "Create a new version of a module",
-				Flags: []cli.Flag{
-					flagModuleID,
-					flagCommitSHA,
-					flagVersion,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagModuleID,
+								flagCommitSHA,
+								flagVersion,
+							},
+							Action:    createVersion,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    createVersion,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Module management",
 				Name:     "delete-version",
 				Usage:    "Delete a version of a module",
-				Flags: []cli.Flag{
-					flagModuleID,
-					flagVersionID,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagModuleID,
+								flagVersionID,
+							},
+							Action:    deleteVersion,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    deleteVersion,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Module management",
 				Name:     "local-preview",
 				Usage:    "Start a preview (proposed version) based on the current project. Respects .gitignore and .terraformignore.",
-				Flags: []cli.Flag{
-					flagModuleID,
-					flagNoFindRepositoryRoot,
-					flagNoUpload,
-					flagRunMetadata,
-					flagDisregardGitignore,
-					flagTests,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagModuleID,
+								flagNoFindRepositoryRoot,
+								flagNoUpload,
+								flagRunMetadata,
+								flagDisregardGitignore,
+								flagTests,
+							},
+							Action:    localPreview(false),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+					{
+						EarliestVersion: cmd.SupportedVersion("2.5.0"),
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagModuleID,
+								flagNoFindRepositoryRoot,
+								flagNoUpload,
+								flagRunMetadata,
+								flagDisregardGitignore,
+								flagTests,
+							},
+							Action:    localPreview(true),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    localPreview(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Module management",
 				Name:     "list",
 				Usage:    "List all modules available and their current version",
-				Flags: []cli.Flag{
-					cmd.FlagOutputFormat,
-					cmd.FlagLimit,
-					cmd.FlagSearch,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagOutputFormat,
+								cmd.FlagLimit,
+								cmd.FlagSearch,
+							},
+							Action:    listModules(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    listModules(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Module management",
 				Name:     "list-versions",
 				Usage:    "List 20 latest non failed versions for a module",
-				Flags: []cli.Flag{
-					flagModuleID,
-					cmd.FlagOutputFormat,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagModuleID,
+								cmd.FlagOutputFormat,
+							},
+							Action:    listVersions(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    listVersions(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 		},
 	}

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -7,73 +7,114 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
-// Command encapsulates the policyNode command subtree.
-func Command() *cli.Command {
-	return &cli.Command{
+// Command returns the versioned policy command subtree.
+func Command() cmd.Command {
+	return cmd.Command{
 		Name:  "policy",
 		Usage: "Manage Spacelift policies",
-		Subcommands: []*cli.Command{
+		Versions: []cmd.VersionedCommand{
+			{
+				EarliestVersion: cmd.SupportedVersionAll,
+				Command:         &cli.Command{},
+			},
+		},
+		Subcommands: []cmd.Command{
 			{
 				Name:  "list",
 				Usage: "List the policies you have access to",
-				Flags: []cli.Flag{
-					cmd.FlagOutputFormat,
-					cmd.FlagLimit,
-					cmd.FlagSearch,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagOutputFormat,
+								cmd.FlagLimit,
+								cmd.FlagSearch,
+							},
+							Action: (&listCommand{}).list,
+							Before: cmd.PerformAllBefore(
+								cmd.HandleNoColor,
+								authenticated.Ensure,
+							),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action: (&listCommand{}).list,
-				Before: cmd.PerformAllBefore(
-					cmd.HandleNoColor,
-					authenticated.Ensure,
-				),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "show",
 				Usage: "Shows detailed information about a specific policy",
-				Flags: []cli.Flag{
-					cmd.FlagOutputFormat,
-					flagRequiredPolicyID,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagOutputFormat,
+								flagRequiredPolicyID,
+							},
+							Action:    (&showCommand{}).show,
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    (&showCommand{}).show,
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "samples",
 				Usage: "List all policy samples",
-				Flags: []cli.Flag{
-					cmd.FlagOutputFormat,
-					cmd.FlagNoColor,
-					flagRequiredPolicyID,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagOutputFormat,
+								cmd.FlagNoColor,
+								flagRequiredPolicyID,
+							},
+							Action:    (&samplesCommand{}).list,
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    (&samplesCommand{}).list,
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "sample",
 				Usage: "Inspect one policy sample",
-				Flags: []cli.Flag{
-					cmd.FlagNoColor,
-					flagRequiredPolicyID,
-					flagRequiredSampleKey,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagNoColor,
+								flagRequiredPolicyID,
+								flagRequiredSampleKey,
+							},
+							Action:    (&sampleCommand{}).show,
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    (&sampleCommand{}).show,
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "simulate",
 				Usage: "Simulate a policy using a sample",
-				Flags: []cli.Flag{
-					cmd.FlagNoColor,
-					flagRequiredPolicyID,
-					flagSimulationInput,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagNoColor,
+								flagRequiredPolicyID,
+								flagSimulationInput,
+							},
+							Action:    (&simulateCommand{}).simulate,
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    (&simulateCommand{}).simulate,
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 		},
 	}

--- a/internal/cmd/provider/provider.go
+++ b/internal/cmd/provider/provider.go
@@ -8,96 +8,158 @@ import (
 )
 
 // Command encapsulates the provider command subtree.
-func Command() *cli.Command {
-	return &cli.Command{
+func Command() cmd.Command {
+	return cmd.Command{
 		Name:  "provider",
 		Usage: "Manage a Terraform provider",
-		Subcommands: []*cli.Command{
+		Versions: []cmd.VersionedCommand{
+			{
+				EarliestVersion: cmd.SupportedVersionAll,
+				Command:         &cli.Command{},
+			},
+		},
+		Subcommands: []cmd.Command{
 			{
 				Category: "GPG key management",
 				Name:     "add-gpg-key",
 				Usage:    "Adds a new GPG key for signing provider releases",
-				Flags: []cli.Flag{
-					flagKeyEmail,
-					flagKeyGenerate,
-					flagKeyImport,
-					flagKeyName,
-					flagKeyPath,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagKeyEmail,
+								flagKeyGenerate,
+								flagKeyImport,
+								flagKeyName,
+								flagKeyPath,
+							},
+							Action:    addGPGKey(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    addGPGKey(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
-				Category:  "GPG key management",
-				Name:      "list-gpg-keys",
-				Usage:     "List all GPG keys registered in the account",
-				Flags:     []cli.Flag{cmd.FlagOutputFormat},
-				Action:    listGPGKeys(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
+				Category: "GPG key management",
+				Name:     "list-gpg-keys",
+				Usage:    "List all GPG keys registered in the account",
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags:     []cli.Flag{cmd.FlagOutputFormat},
+							Action:    listGPGKeys(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+				},
 			},
 			{
-				Category:  "GPG key management",
-				Name:      "revoke-gpg-key",
-				Usage:     "Revoke a GPG key",
-				Flags:     []cli.Flag{flagKeyID},
-				Action:    revokeGPGKey(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
+				Category: "GPG key management",
+				Name:     "revoke-gpg-key",
+				Usage:    "Revoke a GPG key",
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags:     []cli.Flag{flagKeyID},
+							Action:    revokeGPGKey(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+				},
 			},
 			{
 				Category: "Version management",
 				Name:     "create-version",
 				Usage:    "Create a new provider version, designed to be called from a CI/CD pipeline",
-				Flags: []cli.Flag{
-					flagProviderType,
-					flagProviderVersionProtocols,
-					flagGoReleaserDir,
-					flagGPGKeyID,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagProviderType,
+								flagProviderVersionProtocols,
+								flagGoReleaserDir,
+								flagGPGKeyID,
+							},
+							Action:    createVersion(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    createVersion(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
-				Category:  "Version management",
-				Name:      "delete-version",
-				Usage:     "Delete a draft provider version",
-				Flags:     []cli.Flag{flagRequiredVersionID},
-				Action:    deleteVersion(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
+				Category: "Version management",
+				Name:     "delete-version",
+				Usage:    "Delete a draft provider version",
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags:     []cli.Flag{flagRequiredVersionID},
+							Action:    deleteVersion(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+				},
 			},
 			{
 				Category: "Version management",
 				Name:     "list-versions",
 				Usage:    "List all versions of a provider",
-				Flags: []cli.Flag{
-					flagProviderType,
-					cmd.FlagOutputFormat,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagProviderType,
+								cmd.FlagOutputFormat,
+							},
+							Action:    listVersions(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    listVersions(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
-				Category:  "Version management",
-				Name:      "publish-version",
-				Usage:     "Publish a draft provider version",
-				Flags:     []cli.Flag{flagRequiredVersionID},
-				Action:    publishVersion(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
+				Category: "Version management",
+				Name:     "publish-version",
+				Usage:    "Publish a draft provider version",
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags:     []cli.Flag{flagRequiredVersionID},
+							Action:    publishVersion(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+				},
 			},
 			{
-				Category:  "Version management",
-				Name:      "revoke-version",
-				Usage:     "Revoke a published provider version",
-				Flags:     []cli.Flag{flagRequiredVersionID},
-				Action:    revokeVersion(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
+				Category: "Version management",
+				Name:     "revoke-version",
+				Usage:    "Revoke a published provider version",
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags:     []cli.Flag{flagRequiredVersionID},
+							Action:    revokeVersion(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+				},
 			},
 		},
 	}

--- a/internal/cmd/run_external_dependency/run_external_dependency.go
+++ b/internal/cmd/run_external_dependency/run_external_dependency.go
@@ -8,22 +8,35 @@ import (
 )
 
 // Command encapsulates the run external dependency command subtree.
-func Command() *cli.Command {
-	return &cli.Command{
+func Command() cmd.Command {
+	return cmd.Command{
 		Name:  "run-external-dependency",
 		Usage: "Manage Spacelift Run external dependencies",
-		Subcommands: []*cli.Command{
+		Versions: []cmd.VersionedCommand{
+			{
+				EarliestVersion: cmd.SupportedVersionAll,
+				Command:         &cli.Command{},
+			},
+		},
+		Subcommands: []cmd.Command{
 			{
 				Category: "Run external dependency management",
 				Name:     "mark-completed",
 				Usage:    "Mark Run external dependency as completed",
-				Flags: []cli.Flag{
-					flagRunExternalDependencyID,
-					flagStatus,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagRunExternalDependencyID,
+								flagStatus,
+							},
+							Action:    markRunExternalDependencyAsCompleted,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    markRunExternalDependencyAsCompleted,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 		},
 	}

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
-func localPreview() cli.ActionFunc {
+func localPreview(useHeaders bool) cli.ActionFunc {
 	return func(cliCtx *cli.Context) error {
 		envVars, err := parseEnvVariablesForLocalPreview(cliCtx)
 		if err != nil {
@@ -67,23 +67,55 @@ func localPreview() cli.ActionFunc {
 			fmt.Printf("Packing '%s' as local workspace...\n", *packagePath)
 		}
 
-		var uploadMutation struct {
-			UploadLocalWorkspace struct {
-				ID            string            `graphql:"id"`
-				UploadURL     string            `graphql:"uploadUrl"`
-				UploadHeaders structs.StringMap `graphql:"uploadHeaders"`
-			} `graphql:"uploadLocalWorkspace(stack: $stack)"`
+		// Define concrete types
+		type basicResponse struct {
+			ID        string `graphql:"id"`
+			UploadURL string `graphql:"uploadUrl"`
 		}
+
+		type headersResponse struct {
+			ID            string            `graphql:"id"`
+			UploadURL     string            `graphql:"uploadUrl"`
+			UploadHeaders structs.StringMap `graphql:"uploadHeaders"`
+		}
+
+		var workspaceID string
+		var uploadURL string
+		var headers map[string]string
 
 		uploadVariables := map[string]interface{}{
 			"stack": graphql.ID(stack.ID),
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &uploadMutation, uploadVariables); err != nil {
-			return fmt.Errorf("failed to upload local workspace: %w", err)
+		if useHeaders {
+			// Use the headers response struct
+			var headersMutation struct {
+				UploadLocalWorkspace headersResponse `graphql:"uploadLocalWorkspace(stack: $stack)"`
+			}
+
+			if err := authenticated.Client.Mutate(ctx, &headersMutation, uploadVariables); err != nil {
+				return fmt.Errorf("failed to upload local workspace: %w", err)
+			}
+
+			workspaceID = headersMutation.UploadLocalWorkspace.ID
+			uploadURL = headersMutation.UploadLocalWorkspace.UploadURL
+			headers = headersMutation.UploadLocalWorkspace.UploadHeaders.StdMap()
+		} else {
+			// Use the basic response struct
+			var basicMutation struct {
+				UploadLocalWorkspace basicResponse `graphql:"uploadLocalWorkspace(stack: $stack)"`
+			}
+
+			if err := authenticated.Client.Mutate(ctx, &basicMutation, uploadVariables); err != nil {
+				return fmt.Errorf("failed to upload local workspace: %w", err)
+			}
+
+			workspaceID = basicMutation.UploadLocalWorkspace.ID
+			uploadURL = basicMutation.UploadLocalWorkspace.UploadURL
+			headers = nil
 		}
 
-		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", uploadMutation.UploadLocalWorkspace.ID))
+		fp := filepath.Join(os.TempDir(), "spacectl", "local-workspace", fmt.Sprintf("%s.tar.gz", workspaceID))
 
 		ignoreFiles := []string{".terraformignore"}
 		if !cliCtx.IsSet(flagDisregardGitignore.Name) {
@@ -112,7 +144,7 @@ func localPreview() cli.ActionFunc {
 
 		fmt.Println("Uploading local workspace...")
 
-		if err := internal.UploadArchive(ctx, uploadMutation.UploadLocalWorkspace.UploadURL, fp, uploadMutation.UploadLocalWorkspace.UploadHeaders.StdMap()); err != nil {
+		if err := internal.UploadArchive(ctx, uploadURL, fp, headers); err != nil {
 			return fmt.Errorf("couldn't upload archive: %w", err)
 		}
 
@@ -124,7 +156,7 @@ func localPreview() cli.ActionFunc {
 
 		triggerVariables := map[string]interface{}{
 			"stack":                    graphql.ID(stack.ID),
-			"workspace":                graphql.ID(uploadMutation.UploadLocalWorkspace.ID),
+			"workspace":                graphql.ID(workspaceID),
 			"environmentVarsOverrides": envVars,
 		}
 

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -7,238 +7,383 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
-// Command encapsulates the stack command subtree.
-func Command() *cli.Command {
-	return &cli.Command{
+// Command returns the stack command subtree.
+func Command() cmd.Command {
+	return cmd.Command{
 		Name:  "stack",
 		Usage: "Manage a Spacelift stack",
-		Subcommands: []*cli.Command{
+		Versions: []cmd.VersionedCommand{
+			{
+				EarliestVersion: cmd.SupportedVersionAll,
+				Command:         &cli.Command{},
+			},
+		},
+		Subcommands: []cmd.Command{
 			{
 				Category: "Run management",
 				Name:     "confirm",
 				Usage:    "Confirm an unconfirmed tracked run",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRequiredRun,
-					flagRunMetadata,
-					flagTail,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+								flagRunMetadata,
+								flagTail,
+							},
+							Action:    runConfirm(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runConfirm(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "discard",
 				Usage:    "Discard an unconfirmed tracked run",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRequiredRun,
-					flagTail,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+								flagTail,
+							},
+							Action:    runDiscard(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runDiscard(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "cancel",
 				Usage:    "Cancel a run that hasn't started yet",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRequiredRun,
-					flagTail,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+								flagTail,
+							},
+							Action:    runCancel(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runCancel(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "approve",
 				Usage:    "Approves a run or task. If no run is specified, the approval will be added to the current stack blocker.",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRun,
-					flagRunReviewNote,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRun,
+								flagRunReviewNote,
+							},
+							Action:    runApprove,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runApprove,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "reject",
 				Usage:    "Rejects a run or task. If no run is specified, the rejection will be added to the current stack blocker.",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRun,
-					flagRunReviewNote,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRun,
+								flagRunReviewNote,
+							},
+							Action:    runReject,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runReject,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "deploy",
 				Usage:    "Start a deployment (tracked run)",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagCommitSHA,
-					flagRunMetadata,
-					flagTail,
-					flagAutoConfirm,
-					flagRuntimeConfig,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagCommitSHA,
+								flagRunMetadata,
+								flagTail,
+								flagAutoConfirm,
+								flagRuntimeConfig,
+							},
+							Action:    runTrigger("TRACKED", "deployment"),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runTrigger("TRACKED", "deployment"),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "retry",
 				Usage:    "Retry a failed run",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRequiredRun,
-					flagTail,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+								flagTail,
+							},
+							Action:    runRetry,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runRetry,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "replan",
 				Usage:    "Replan an unconfirmed tracked run",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRequiredRun,
-					flagTail,
-					flagResources,
-					flagInteractive,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+								flagTail,
+								flagResources,
+								flagInteractive,
+							},
+							Action:    runReplan,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runReplan,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "changes",
 				Usage:    "Show a list of changes for a given run",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRequiredRun,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+							},
+							Action:    runChanges,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runChanges,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "list",
 				Usage: "List the stacks you have access to",
-				Flags: []cli.Flag{
-					cmd.FlagShowLabels,
-					cmd.FlagOutputFormat,
-					cmd.FlagNoColor,
-					cmd.FlagLimit,
-					cmd.FlagSearch,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagShowLabels,
+								cmd.FlagOutputFormat,
+								cmd.FlagNoColor,
+								cmd.FlagLimit,
+								cmd.FlagSearch,
+							},
+							Action:    listStacks(),
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    listStacks(),
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run local preview",
 				Name:     "local-preview",
 				Usage:    "Start a preview (proposed run) based on the current project. Respects .gitignore and .terraformignore.",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagNoFindRepositoryRoot,
-					flagProjectRootOnly,
-					flagRunMetadata,
-					flagNoTail,
-					flagNoUpload,
-					flagOverrideEnvVars,
-					flagOverrideEnvVarsTF,
-					flagDisregardGitignore,
-					flagPrioritizeRun,
-					flagTarget,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagNoFindRepositoryRoot,
+								flagProjectRootOnly,
+								flagRunMetadata,
+								flagNoTail,
+								flagNoUpload,
+								flagOverrideEnvVars,
+								flagOverrideEnvVarsTF,
+								flagDisregardGitignore,
+								flagPrioritizeRun,
+								flagTarget,
+							},
+							Action:    localPreview(false),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+					{
+						EarliestVersion: cmd.SupportedVersion("2.5.0"),
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagNoFindRepositoryRoot,
+								flagProjectRootOnly,
+								flagRunMetadata,
+								flagNoTail,
+								flagNoUpload,
+								flagOverrideEnvVars,
+								flagOverrideEnvVarsTF,
+								flagDisregardGitignore,
+								flagPrioritizeRun,
+								flagTarget,
+							},
+							Action:    localPreview(true),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    localPreview(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "logs",
 				Usage:    "Show logs for a particular run",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRun,
-					flagRunLatest,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRun,
+								flagRunLatest,
+							},
+							Action:    runLogs,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runLogs,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "preview",
 				Usage:    "Start a preview (proposed run)",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagCommitSHA,
-					flagRunMetadata,
-					flagTail,
-					flagRuntimeConfig,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagCommitSHA,
+								flagRunMetadata,
+								flagTail,
+								flagRuntimeConfig,
+							},
+							Action:    runTrigger("PROPOSED", "preview"),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runTrigger("PROPOSED", "preview"),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "prioritize",
 				Usage:    "Prioritize a run",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRequiredRun,
-					flagTail,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+								flagTail,
+							},
+							Action:    runPrioritize,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runPrioritize,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Run management",
 				Name:     "deprioritize",
 				Usage:    "Deprioritize a run",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRequiredRun,
-					flagTail,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+								flagTail,
+							},
+							Action:    runDeprioritize,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    runDeprioritize,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "run",
 				Usage: "Manage a stack's runs",
-				Subcommands: []*cli.Command{
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command:         &cli.Command{},
+					},
+				},
+				Subcommands: []cmd.Command{
 					{
 						Name:  "list",
 						Usage: "Lists the runs for a specified stack",
-						Flags: []cli.Flag{
-							flagStackID,
-							flagMaxResults,
-							cmd.FlagOutputFormat,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagStackID,
+										flagMaxResults,
+										cmd.FlagOutputFormat,
+									},
+									Action:    runList,
+									Before:    authenticated.Ensure,
+									ArgsUsage: cmd.EmptyArgsUsage,
+								},
+							},
 						},
-						Action:    runList,
-						Before:    authenticated.Ensure,
-						ArgsUsage: cmd.EmptyArgsUsage,
 					},
 				},
 			},
@@ -246,236 +391,380 @@ func Command() *cli.Command {
 				Category: "Stack management",
 				Name:     "set-current-commit",
 				Usage:    "Set current commit on the stack",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRun,
-					flagRequiredCommitSHA,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRun,
+								flagRequiredCommitSHA,
+							},
+							Action:    setCurrentCommit,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    setCurrentCommit,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "environment",
 				Usage: "Manage a stack's environment",
-				Subcommands: []*cli.Command{
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command:         &cli.Command{},
+					},
+				},
+				Subcommands: []cmd.Command{
 					{
 						Name:  "setvar",
 						Usage: "Sets an environment variable.",
-						Flags: []cli.Flag{
-							flagStackID,
-							flagRun,
-							flagEnvironmentWriteOnly,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagStackID,
+										flagRun,
+										flagEnvironmentWriteOnly,
+									},
+									Action:    setVar,
+									Before:    authenticated.Ensure,
+									ArgsUsage: "NAME VALUE",
+								},
+							},
 						},
-						Action:    setVar,
-						Before:    authenticated.Ensure,
-						ArgsUsage: "NAME VALUE",
 					},
 					{
 						Name:  "list",
 						Usage: "Lists all the environment variables and mounted files for a stack.",
-						Flags: []cli.Flag{
-							flagStackID,
-							flagRun,
-							cmd.FlagOutputFormat,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagStackID,
+										flagRun,
+										cmd.FlagOutputFormat,
+									},
+									Action: (&listEnvCommand{}).listEnv,
+									Before: authenticated.Ensure,
+								},
+							},
 						},
-						Action: (&listEnvCommand{}).listEnv,
-						Before: authenticated.Ensure,
 					},
 					{
 						Name:  "mount",
 						Usage: "Mount a file from existing file or STDIN.",
-						Flags: []cli.Flag{
-							flagStackID,
-							flagRun,
-							flagEnvironmentWriteOnly,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagStackID,
+										flagRun,
+										flagEnvironmentWriteOnly,
+									},
+									Action:    mountFile,
+									Before:    authenticated.Ensure,
+									ArgsUsage: "RELATIVE_PATH_TO_MOUNT [FILE_PATH]",
+								},
+							},
 						},
-						Action:    mountFile,
-						Before:    authenticated.Ensure,
-						ArgsUsage: "RELATIVE_PATH_TO_MOUNT [FILE_PATH]",
 					},
 					{
 						Name:  "delete",
 						Usage: "Deletes an environment variable or mounted file.",
-						Flags: []cli.Flag{
-							flagStackID,
-							flagRun,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagStackID,
+										flagRun,
+									},
+									Action:    deleteEnvironment,
+									Before:    authenticated.Ensure,
+									ArgsUsage: "NAME",
+								},
+							},
 						},
-						Action:    deleteEnvironment,
-						Before:    authenticated.Ensure,
-						ArgsUsage: "NAME",
 					},
 				},
 			},
 			{
 				Name:  "outputs",
 				Usage: "Shows current outputs for a specific stack. Does not show the value of sensitive outputs.",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRun,
-					flagOutputID,
-					cmd.FlagOutputFormat,
-					cmd.FlagNoColor,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRun,
+								flagOutputID,
+								cmd.FlagOutputFormat,
+								cmd.FlagNoColor,
+							},
+							Action:    (&showOutputsStackCommand{}).showOutputs,
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    (&showOutputsStackCommand{}).showOutputs,
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "show",
 				Usage: "Shows detailed information about a specific stack",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRun,
-					cmd.FlagOutputFormat,
-					cmd.FlagNoColor,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRun,
+								cmd.FlagOutputFormat,
+								cmd.FlagNoColor,
+							},
+							Action:    (&showStackCommand{}).showStack,
+							Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    (&showStackCommand{}).showStack,
-				Before:    cmd.PerformAllBefore(cmd.HandleNoColor, authenticated.Ensure),
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Stack management",
 				Name:     "open",
 				Usage:    "Open a stack in your browser",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagRun,
-					flagIgnoreSubdir,
-					flagCurrentBranch,
-					flagSearchCount,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRun,
+								flagIgnoreSubdir,
+								flagCurrentBranch,
+								flagSearchCount,
+							},
+							Action:    openCommandInBrowser,
+							Before:    authenticated.Ensure,
+							ArgsUsage: "COMMAND",
+						},
+					},
 				},
-				Action:    openCommandInBrowser,
-				Before:    authenticated.Ensure,
-				ArgsUsage: "COMMAND",
 			},
 			{
 				Category: "Run management",
 				Name:     "task",
 				Usage:    "Perform a task in a stack",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagNoInit,
-					flagRunMetadata,
-					flagTail,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagNoInit,
+								flagRunMetadata,
+								flagTail,
+							},
+							Action:    taskCommand,
+							Before:    authenticated.Ensure,
+							ArgsUsage: "COMMAND",
+						},
+					},
 				},
-				Action:    taskCommand,
-				Before:    authenticated.Ensure,
-				ArgsUsage: "COMMAND",
 			},
 			{
 				Category: "Stack management",
 				Name:     "lock",
 				Usage:    "Locks a stack for exclusive use.",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagStackLockNote,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagStackLockNote,
+							},
+							Action:    lock,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    lock,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Stack management",
 				Name:     "unlock",
 				Usage:    "Unlocks a stack.",
-				Flags: []cli.Flag{
-					flagStackID,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+							},
+							Action:    unlock,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    unlock,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Stack management",
 				Name:     "enable",
 				Usage:    "Enable new runs against the stack",
-				Flags: []cli.Flag{
-					flagStackID,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+							},
+							Action:    enable,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    enable,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Stack management",
 				Name:     "disable",
 				Usage:    "Disable new runs against the stack",
-				Flags: []cli.Flag{
-					flagStackID,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+							},
+							Action:    disable,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    disable,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Stack management",
 				Name:     "sync-commit",
 				Usage:    "Syncs the tracked stack commit",
-				Flags: []cli.Flag{
-					flagStackID,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+							},
+							Action:    syncCommit,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    syncCommit,
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Category: "Stack management",
 				Name:     "delete",
 				Usage:    "Delete a stack",
-				Flags: []cli.Flag{
-					flagStackID,
-					flagDestroyResources,
-					flagSkipConfirmation,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagDestroyResources,
+								flagSkipConfirmation,
+							},
+							Action:    deleteStack(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
 				},
-				Action:    deleteStack(),
-				Before:    authenticated.Ensure,
-				ArgsUsage: cmd.EmptyArgsUsage,
 			},
 			{
 				Name:  "resources",
 				Usage: "Manage and view resources for stacks",
-				Subcommands: []*cli.Command{
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command:         &cli.Command{},
+					},
+				},
+				Subcommands: []cmd.Command{
 					{
 						Name:  "list",
 						Usage: "Sets an environment variable.",
-						Flags: []cli.Flag{
-							flagStackID,
-							flagRun,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagStackID,
+										flagRun,
+									},
+									Action:    resourcesList,
+									Before:    authenticated.Ensure,
+									ArgsUsage: cmd.EmptyArgsUsage,
+								},
+							},
 						},
-						Action:    resourcesList,
-						Before:    authenticated.Ensure,
-						ArgsUsage: cmd.EmptyArgsUsage,
 					},
 				},
 			},
 			{
 				Name:  "dependencies",
 				Usage: "View stack dependencies",
-				Subcommands: []*cli.Command{
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command:         &cli.Command{},
+					},
+				},
+				Subcommands: []cmd.Command{
 					{
 						Name:  "on",
 						Usage: "Get stacks which the provided that depends on",
-						Flags: []cli.Flag{
-							flagStackID,
-							flagRun,
-							cmd.FlagOutputFormat,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagStackID,
+										flagRun,
+										cmd.FlagOutputFormat,
+									},
+									Action:    dependenciesOn,
+									Before:    authenticated.Ensure,
+									ArgsUsage: cmd.EmptyArgsUsage,
+								},
+							},
 						},
-						Action:    dependenciesOn,
-						Before:    authenticated.Ensure,
-						ArgsUsage: cmd.EmptyArgsUsage,
 					},
 					{
 						Name:  "off",
 						Usage: "Get stacks that depend on the provided stack",
-						Flags: []cli.Flag{
-							flagStackID,
-							flagRun,
-							cmd.FlagOutputFormat,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagStackID,
+										flagRun,
+										cmd.FlagOutputFormat,
+									},
+									Action:    dependenciesOff,
+									Before:    authenticated.Ensure,
+									ArgsUsage: cmd.EmptyArgsUsage,
+								},
+							},
 						},
-						Action:    dependenciesOff,
-						Before:    authenticated.Ensure,
-						ArgsUsage: cmd.EmptyArgsUsage,
 					},
 				},
 			},

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -5,15 +5,17 @@ import (
 	"os"
 
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd"
 )
 
 // Command returns the CLI version.
-func Command(version string) *cli.Command {
+func Command(spacectlVersion string, spaceliftVersion cmd.SpaceliftInstanceVersion) *cli.Command {
 	return &cli.Command{
 		Name:  "version",
 		Usage: "Print out CLI version",
 		Action: func(*cli.Context) error {
-			_, err := fmt.Fprintln(os.Stdout, version)
+			_, err := fmt.Fprintf(os.Stdout, "spacectl version: %s, Spacelift version: %s\n", spacectlVersion, spaceliftVersion.String())
 			return err
 		},
 	}

--- a/internal/cmd/workerpools/cmd.go
+++ b/internal/cmd/workerpools/cmd.go
@@ -8,69 +8,123 @@ import (
 )
 
 // Command encapsulates the workerpool command subtree.
-func Command() *cli.Command {
-	return &cli.Command{
+func Command() cmd.Command {
+	return cmd.Command{
 		Name:  "workerpool",
 		Usage: "Manages workerpools and their workers.",
-		Subcommands: []*cli.Command{
+		Versions: []cmd.VersionedCommand{
+			{
+				EarliestVersion: cmd.SupportedVersionAll,
+				Command:         &cli.Command{},
+			},
+		},
+		Subcommands: []cmd.Command{
 			{
 				Name:  "list",
 				Usage: "Lists all worker pools.",
-				Flags: []cli.Flag{
-					cmd.FlagOutputFormat,
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								cmd.FlagOutputFormat,
+							},
+							Action: (&listPoolsCommand{}).listPools,
+							Before: authenticated.Ensure,
+						},
+					},
 				},
-				Action: (&listPoolsCommand{}).listPools,
-				Before: authenticated.Ensure,
 			},
 			{
-				Name:   "watch",
-				Usage:  "Starts an interactive watcher for a worker pool",
-				Action: watch,
-				Before: authenticated.Ensure,
+				Name:  "watch",
+				Usage: "Starts an interactive watcher for a worker pool",
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Action: watch,
+							Before: authenticated.Ensure,
+						},
+					},
+				},
 			},
 			{
 				Name:  "worker",
 				Usage: "Contains commands for managing workers within a pool.",
-				Subcommands: []*cli.Command{
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command:         &cli.Command{},
+					},
+				},
+				Subcommands: []cmd.Command{
 					{
 						Name:  "cycle",
 						Usage: "Sends a kill signal to all workers in a workerpool.",
-						Flags: []cli.Flag{
-							flagPoolIDNamed,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagPoolIDNamed,
+									},
+									Action: (&cycleWorkersCommand{}).cycleWorkers,
+									Before: authenticated.Ensure,
+								},
+							},
 						},
-						Action: (&cycleWorkersCommand{}).cycleWorkers,
-						Before: authenticated.Ensure,
 					},
 					{
 						Name:  "list",
 						Usage: "Lists all workers of a workerpool.",
-						Flags: []cli.Flag{
-							flagPoolIDNamed,
-							cmd.FlagOutputFormat,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagPoolIDNamed,
+										cmd.FlagOutputFormat,
+									},
+									Action: (&listWorkersCommand{}).listWorkers,
+									Before: authenticated.Ensure,
+								},
+							},
 						},
-						Action: (&listWorkersCommand{}).listWorkers,
-						Before: authenticated.Ensure,
 					},
 					{
 						Name:  "drain",
 						Usage: "Drains a worker.",
-						Flags: []cli.Flag{
-							flagWorkerID,
-							flagPoolIDNamed,
-							flagWaitUntilDrained,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagWorkerID,
+										flagPoolIDNamed,
+										flagWaitUntilDrained,
+									},
+									Action: (&drainWorkerCommand{}).drainWorker,
+									Before: authenticated.Ensure,
+								},
+							},
 						},
-						Action: (&drainWorkerCommand{}).drainWorker,
-						Before: authenticated.Ensure,
 					},
 					{
 						Name:  "undrain",
 						Usage: "Undrains a worker.",
-						Flags: []cli.Flag{
-							flagWorkerID,
-							flagPoolIDNamed,
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command: &cli.Command{
+									Flags: []cli.Flag{
+										flagWorkerID,
+										flagPoolIDNamed,
+									},
+									Action: (&undrainWorkerCommand{}).undrainWorker,
+									Before: authenticated.Ensure,
+								},
+							},
 						},
-						Action: (&undrainWorkerCommand{}).undrainWorker,
-						Before: authenticated.Ensure,
 					},
 				},
 			},

--- a/internal/nullable/nullable.go
+++ b/internal/nullable/nullable.go
@@ -1,0 +1,15 @@
+package nullable
+
+// OfValue returns a pointer to the value.
+func OfValue[T any](value T) *T {
+	return &value
+}
+
+// GetValue returns the value of the pointer, or the zero value if the pointer is nil.
+func GetValue[T any](value *T) T {
+	var defaultValue T
+	if value != nil {
+		defaultValue = *value
+	}
+	return defaultValue
+}

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -1,0 +1,13 @@
+package slices
+
+// Filter return items that pass the filter function.
+func Filter[T any](src []T, predicate func(item T) bool) []T {
+	var dst []T
+	for _, item := range src {
+		if predicate(item) {
+			dst = append(dst, item)
+		}
+	}
+
+	return dst
+}

--- a/main.go
+++ b/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/urfave/cli/v2"
 
+	"github.com/spacelift-io/spacectl/client"
+	"github.com/spacelift-io/spacectl/client/session"
+	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/audittrail"
 	"github.com/spacelift-io/spacectl/internal/cmd/blueprint"
 	"github.com/spacelift-io/spacectl/internal/cmd/completion"
@@ -24,31 +29,88 @@ import (
 var version = "dev"
 var date = "2006-01-02T15:04:05Z"
 
+type debugInfoQuery struct {
+	DebugInfo struct {
+		SelfHostedVersion string `graphql:"selfHostedVersion"`
+	} `graphql:"debugInfo"`
+}
+
+func getSpaceliftInstanceVersion() cmd.SpaceliftInstanceVersion {
+	instanceVersion := cmd.SpaceliftInstanceVersion{
+		InstanceType: cmd.SpaceliftInstanceTypeUnknown,
+	}
+
+	ctx, httpClient := session.Defaults()
+
+	// Create a new session - this may fail if the user doesn't have valid credentials.
+	// In that case we just treat the version as unknown.
+	sess, err := session.New(ctx, httpClient)
+	if err != nil {
+		return instanceVersion
+	}
+
+	c := client.New(httpClient, sess)
+
+	// Query the GraphQL API for the actual version. If this fails, we also treat the
+	// version as unknown.
+	var query debugInfoQuery
+	if err := c.Query(context.Background(), &query, nil); err != nil {
+		return instanceVersion
+	}
+
+	// If the query succeeds, determine if this is a SaaS or Self-Hosted instance
+	if query.DebugInfo.SelfHostedVersion == "" {
+		// Empty version means SaaS
+		instanceVersion.InstanceType = cmd.SpaceliftInstanceTypeSaaS
+	} else {
+		// Non-empty version means Self-Hosted
+		instanceVersion.InstanceType = cmd.SpaceliftInstanceTypeSelfHosted
+
+		v, err := semver.NewVersion(query.DebugInfo.SelfHostedVersion)
+		if err == nil {
+			instanceVersion.Version = v
+		} else {
+			log.Printf("Warning: Failed to parse Self-Hosted version string: %q: %v",
+				query.DebugInfo.SelfHostedVersion, err)
+		}
+	}
+
+	return instanceVersion
+}
+
 func main() {
 	compileTime, err := time.Parse(time.RFC3339, date)
 	if err != nil {
 		log.Fatalf("Could not parse compilation date: %v", err)
 	}
+
+	instanceVersion := getSpaceliftInstanceVersion()
+
+	if instanceVersion.InstanceType == cmd.SpaceliftInstanceTypeUnknown {
+		log.Println("Warning: Unable to determine Spacelift instance type. Some commands may be unavailable until you authenticate with Spacelift.")
+	}
+
 	app := &cli.App{
 		Name:                 "spacectl",
 		Version:              version,
 		Compiled:             compileTime,
 		Usage:                "Programmatic access to Spacelift GraphQL API.",
 		EnableBashCompletion: true,
-		Commands: []*cli.Command{
-			module.Command(),
+		Commands: append([]*cli.Command{
 			profile.Command(),
+			whoami.Command(),
+			versioncmd.Command(version, instanceVersion),
+			completion.Command(),
+		}, cmd.ResolveCommands(instanceVersion, []cmd.Command{
+			module.Command(),
+			stack.Command(),
 			provider.Command(),
 			runexternaldependency.Command(),
-			stack.Command(),
-			whoami.Command(),
-			versioncmd.Command(version),
 			workerpools.Command(),
-			completion.Command(),
 			blueprint.Command(),
 			policy.Command(),
 			audittrail.Command(),
-		},
+		})...),
 	}
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
I've added a versioning system to spacectl so that we can maintain backwards compatibility with older Self-Hosted instances while still allowing us to add new functionality. The way it works is by creating a wrapper around the CLI commands which understands the concept of the minimum Spacelift version required. At startup we ask for the version of the Spacelift instance and then resolve the available commands.

This means that customers won't need to worry about what version of Spacectl they run against their Spacelift instance in future - it should just work.

The way it fits into the Self-Hosted release cycle is like this:

1. A new command version is added that relies on GraphQL API functionality not released to any Self-Hosted version yet.
1.1. The new version is marked with `SupportedVersionLatest` so that it is only available to SaaS.
2. Self-Hosted version 1.2.3 is released.
2.1. At this point we update `SupportedVersionLatest` to `SupportedVersion("1.2.3")`, allowing it to be used with the latest version of Self-Hosted.
2.2. Older Self-Hosted versions continue to use the previous version of the command.

There's more details in the [contributing guide](https://github.com/spacelift-io/spacectl/pull/303/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055).

I'm happy to split this PR into smaller chunks - I just want to check the concept makes sense first.