### PR TITLE
fix: golangci-lint gci rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,7 @@ linters-settings:
     sections:
       - standard
       - default
-      - prefix(github.com/spacelift-io/backend)
+      - prefix(github.com/spacelift-io/spacectl)
   goconst:
     min-len: 2
     min-occurrences: 2

--- a/browserauth/browserauth.go
+++ b/browserauth/browserauth.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/spacelift-io/spacectl/internal"
 )

--- a/client/client.go
+++ b/client/client.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/client/session"
 	"golang.org/x/oauth2"
+
+	"github.com/spacelift-io/spacectl/client/session"
 )
 
 type client struct {

--- a/client/session/profile_manager_test.go
+++ b/client/session/profile_manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/franela/goblin"
 	"github.com/onsi/gomega"
+
 	"github.com/spacelift-io/spacectl/client/session"
 )
 

--- a/internal/cmd/audittrail/audit_trail.go
+++ b/internal/cmd/audittrail/audit_trail.go
@@ -1,9 +1,10 @@
 package audittrail
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func Command() *cli.Command {

--- a/internal/cmd/audittrail/list.go
+++ b/internal/cmd/audittrail/list.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 var defaultOrder = structs.QueryOrder{

--- a/internal/cmd/authenticated/client.go
+++ b/internal/cmd/authenticated/client.go
@@ -7,9 +7,10 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client"
 	"github.com/spacelift-io/spacectl/client/session"
-	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/internal/cmd/blueprint/blueprint.go
+++ b/internal/cmd/blueprint/blueprint.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // Command encapsulates the blueprintNode command subtree.

--- a/internal/cmd/blueprint/deploy.go
+++ b/internal/cmd/blueprint/deploy.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 type deployCommand struct{}

--- a/internal/cmd/blueprint/list.go
+++ b/internal/cmd/blueprint/list.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func listBlueprints() cli.ActionFunc {

--- a/internal/cmd/blueprint/show.go
+++ b/internal/cmd/blueprint/show.go
@@ -8,9 +8,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pterm/pterm"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type blueprintInput struct {

--- a/internal/cmd/draw/data/workerpools.go
+++ b/internal/cmd/draw/data/workerpools.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )

--- a/internal/cmd/module/create_version.go
+++ b/internal/cmd/module/create_version.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func createVersion(cliCtx *cli.Context) error {

--- a/internal/cmd/module/delete_version.go
+++ b/internal/cmd/module/delete_version.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func deleteVersion(cliCtx *cli.Context) error {

--- a/internal/cmd/module/list.go
+++ b/internal/cmd/module/list.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func listModules() cli.ActionFunc {

--- a/internal/cmd/module/local_preview.go
+++ b/internal/cmd/module/local_preview.go
@@ -14,11 +14,12 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mholt/archiver/v3"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
-	"golang.org/x/sync/errgroup"
 )
 
 func localPreview() cli.ActionFunc {

--- a/internal/cmd/module/module.go
+++ b/internal/cmd/module/module.go
@@ -1,9 +1,10 @@
 package module
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // Command encapsulates the module command subtree.

--- a/internal/cmd/module/search_version.go
+++ b/internal/cmd/module/search_version.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/internal/cmd/policy/list.go
+++ b/internal/cmd/policy/list.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type listCommand struct{}

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -1,9 +1,10 @@
 package policy
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // Command encapsulates the policyNode command subtree.

--- a/internal/cmd/policy/sample.go
+++ b/internal/cmd/policy/sample.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type policyEvaluationSample struct {

--- a/internal/cmd/policy/samples.go
+++ b/internal/cmd/policy/samples.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type policyEvaluation struct {

--- a/internal/cmd/policy/show.go
+++ b/internal/cmd/policy/show.go
@@ -8,9 +8,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pterm/pterm"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type PolicyType string

--- a/internal/cmd/policy/simulate.go
+++ b/internal/cmd/policy/simulate.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type simulateCommand struct{}

--- a/internal/cmd/profile/current_command.go
+++ b/internal/cmd/profile/current_command.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd"
 )
 
 func currentCommand() *cli.Command {

--- a/internal/cmd/profile/export_token.go
+++ b/internal/cmd/profile/export_token.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd"
 )
 
 func exportTokenCommand() *cli.Command {

--- a/internal/cmd/profile/flags.go
+++ b/internal/cmd/profile/flags.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/client/session"
 )
 
 var bindHost string

--- a/internal/cmd/profile/get_alias_with_profile.go
+++ b/internal/cmd/profile/get_alias_with_profile.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/client/session"
 )
 
 var (

--- a/internal/cmd/profile/list_command.go
+++ b/internal/cmd/profile/list_command.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/spacelift-io/spacectl/internal/cmd"
-	"github.com/urfave/cli/v2"
 )
 
 type profileListOutput struct {

--- a/internal/cmd/profile/login_command.go
+++ b/internal/cmd/profile/login_command.go
@@ -13,10 +13,11 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
-	"github.com/spacelift-io/spacectl/browserauth"
-	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/term"
+
+	"github.com/spacelift-io/spacectl/browserauth"
+	"github.com/spacelift-io/spacectl/client/session"
 )
 
 func loginCommand() *cli.Command {

--- a/internal/cmd/profile/profile.go
+++ b/internal/cmd/profile/profile.go
@@ -3,8 +3,9 @@ package profile
 import (
 	"fmt"
 
-	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/client/session"
 )
 
 var (

--- a/internal/cmd/profile/usage_view_csv_command.go
+++ b/internal/cmd/profile/usage_view_csv_command.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func usageViewCSVCommand() *cli.Command {

--- a/internal/cmd/provider/add_gpg_key.go
+++ b/internal/cmd/provider/add_gpg_key.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
-	"github.com/urfave/cli/v2"
 )
 
 func addGPGKey() cli.ActionFunc {

--- a/internal/cmd/provider/create_version.go
+++ b/internal/cmd/provider/create_version.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
-	"github.com/urfave/cli/v2"
 )
 
 func createVersion() cli.ActionFunc {

--- a/internal/cmd/provider/delete_version.go
+++ b/internal/cmd/provider/delete_version.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
-	"github.com/urfave/cli/v2"
 )
 
 func deleteVersion() cli.ActionFunc {

--- a/internal/cmd/provider/list_gpg_keys.go
+++ b/internal/cmd/provider/list_gpg_keys.go
@@ -3,10 +3,11 @@ package provider
 import (
 	"fmt"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
-	"github.com/urfave/cli/v2"
 )
 
 func listGPGKeys() cli.ActionFunc {

--- a/internal/cmd/provider/list_versions.go
+++ b/internal/cmd/provider/list_versions.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
-	"github.com/urfave/cli/v2"
 )
 
 func listVersions() cli.ActionFunc {

--- a/internal/cmd/provider/provider.go
+++ b/internal/cmd/provider/provider.go
@@ -1,9 +1,10 @@
 package provider
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // Command encapsulates the provider command subtree.

--- a/internal/cmd/provider/publish_version.go
+++ b/internal/cmd/provider/publish_version.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
-	"github.com/urfave/cli/v2"
 )
 
 func publishVersion() cli.ActionFunc {

--- a/internal/cmd/provider/revoke_gpg_key.go
+++ b/internal/cmd/provider/revoke_gpg_key.go
@@ -3,9 +3,10 @@ package provider
 import (
 	"fmt"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
-	"github.com/urfave/cli/v2"
 )
 
 func revokeGPGKey() cli.ActionFunc {

--- a/internal/cmd/provider/revoke_version.go
+++ b/internal/cmd/provider/revoke_version.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/provider/internal"
-	"github.com/urfave/cli/v2"
 )
 
 func revokeVersion() cli.ActionFunc {

--- a/internal/cmd/run_external_dependency/mark_completed.go
+++ b/internal/cmd/run_external_dependency/mark_completed.go
@@ -5,8 +5,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func markRunExternalDependencyAsCompleted(cliCtx *cli.Context) error {

--- a/internal/cmd/run_external_dependency/run_external_dependency.go
+++ b/internal/cmd/run_external_dependency/run_external_dependency.go
@@ -1,9 +1,10 @@
 package runexternaldependency
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // Command encapsulates the run external dependency command subtree.

--- a/internal/cmd/stack/delete.go
+++ b/internal/cmd/stack/delete.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 var flagDestroyResources = &cli.BoolFlag{

--- a/internal/cmd/stack/dependencies.go
+++ b/internal/cmd/stack/dependencies.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func dependenciesOn(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/enable.go
+++ b/internal/cmd/stack/enable.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 type (

--- a/internal/cmd/stack/environment.go
+++ b/internal/cmd/stack/environment.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // ConfigType is a type of configuration element.

--- a/internal/cmd/stack/list.go
+++ b/internal/cmd/stack/list.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd"
-	"github.com/urfave/cli/v2"
 )
 
 func listStacks() cli.ActionFunc {

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/mholt/archiver/v3"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func localPreview() cli.ActionFunc {

--- a/internal/cmd/stack/lock.go
+++ b/internal/cmd/stack/lock.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 type stackLockMutation struct {

--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -11,9 +11,10 @@ import (
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func openCommandInBrowser(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/outputs.go
+++ b/internal/cmd/stack/outputs.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type output struct {

--- a/internal/cmd/stack/resources.go
+++ b/internal/cmd/stack/resources.go
@@ -3,9 +3,10 @@ package stack
 import (
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func resourcesList(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/run_cancel.go
+++ b/internal/cmd/stack/run_cancel.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func runCancel() cli.ActionFunc {

--- a/internal/cmd/stack/run_changes.go
+++ b/internal/cmd/stack/run_changes.go
@@ -3,9 +3,10 @@ package stack
 import (
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func runChanges(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/run_confirm.go
+++ b/internal/cmd/stack/run_confirm.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func runConfirm() cli.ActionFunc {

--- a/internal/cmd/stack/run_deprioritize.go
+++ b/internal/cmd/stack/run_deprioritize.go
@@ -3,8 +3,9 @@ package stack
 import (
 	"fmt"
 
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func runDeprioritize(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/run_discard.go
+++ b/internal/cmd/stack/run_discard.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func runDiscard() cli.ActionFunc {

--- a/internal/cmd/stack/run_list.go
+++ b/internal/cmd/stack/run_list.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func runList(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/run_logs.go
+++ b/internal/cmd/stack/run_logs.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // actionOnRunState is a function that can be executed on a run state.

--- a/internal/cmd/stack/run_prioritize.go
+++ b/internal/cmd/stack/run_prioritize.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func runPrioritize(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/run_replan.go
+++ b/internal/cmd/stack/run_replan.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 const rocketEmoji = "\U0001F680"

--- a/internal/cmd/stack/run_retry.go
+++ b/internal/cmd/stack/run_retry.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func runRetry(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/run_review.go
+++ b/internal/cmd/stack/run_review.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/enums"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type runReviewMutation struct {

--- a/internal/cmd/stack/run_trigger.go
+++ b/internal/cmd/stack/run_trigger.go
@@ -6,10 +6,11 @@ import (
 	"os"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func runTrigger(spaceliftType, humanType string) cli.ActionFunc {

--- a/internal/cmd/stack/set_current_commit.go
+++ b/internal/cmd/stack/set_current_commit.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func setCurrentCommit(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/show.go
+++ b/internal/cmd/stack/show.go
@@ -8,9 +8,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pterm/pterm"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -1,9 +1,10 @@
 package stack
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // Command encapsulates the stack command subtree.

--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -9,9 +9,10 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/internal/cmd/stack/sync.go
+++ b/internal/cmd/stack/sync.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/shurcooL/graphql"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/urfave/cli/v2"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 func syncCommit(cliCtx *cli.Context) error {

--- a/internal/cmd/stack/task_command.go
+++ b/internal/cmd/stack/task_command.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 func taskCommand(cliCtx *cli.Context) error {

--- a/internal/cmd/whoami/whoami.go
+++ b/internal/cmd/whoami/whoami.go
@@ -6,10 +6,11 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // Command returns the logged-in user's information.

--- a/internal/cmd/workerpools/cmd.go
+++ b/internal/cmd/workerpools/cmd.go
@@ -1,9 +1,10 @@
 package workerpools
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 // Command encapsulates the workerpool command subtree.

--- a/internal/cmd/workerpools/pool.go
+++ b/internal/cmd/workerpools/pool.go
@@ -5,9 +5,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 type pool struct {

--- a/internal/cmd/workerpools/watch.go
+++ b/internal/cmd/workerpools/watch.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 
 	"github.com/manifoldco/promptui"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 	"github.com/spacelift-io/spacectl/internal/cmd/draw"
 	"github.com/spacelift-io/spacectl/internal/cmd/draw/data"
-	"github.com/urfave/cli/v2"
 )
 
 func watch(cliCtx *cli.Context) error {

--- a/internal/cmd/workerpools/worker.go
+++ b/internal/cmd/workerpools/worker.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
-	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/spacelift-io/spacectl/internal/cmd/audittrail"
 	"github.com/spacelift-io/spacectl/internal/cmd/blueprint"
 	"github.com/spacelift-io/spacectl/internal/cmd/completion"
@@ -17,7 +19,6 @@ import (
 	versioncmd "github.com/spacelift-io/spacectl/internal/cmd/version"
 	"github.com/spacelift-io/spacectl/internal/cmd/whoami"
 	"github.com/spacelift-io/spacectl/internal/cmd/workerpools"
-	"github.com/urfave/cli/v2"
 )
 
 var version = "dev"


### PR DESCRIPTION
The problem is that it had the wrong repo name defined (`backend` instead of `spacectl`), causing the linter rule to fail.

I've fixed it and run `golangci-lint run --fix ./...` to fix all the package imports that were wrong as a result.