### PR TITLE
fix: revert new ignore matcher

### DIFF
--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/mholt/archiver/v3"
 	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli/v2"
 
@@ -240,11 +241,12 @@ func createLocalPreviewRun(
 		return "", fmt.Errorf("couldn't analyze .gitignore and .terraformignore files")
 	}
 
-	err = internal.CreateArchive(ctx, ".", fp, matchFn)
+	tgz := *archiver.DefaultTarGz
+	tgz.ForceArchiveImplicitTopLevelFolder = true
+	tgz.MatchFn = matchFn
 
-	if err != nil {
-		return "", fmt.Errorf("CreateArchive: %w", err)
-
+	if err := tgz.Archive([]string{"."}, fp); err != nil {
+		return "", fmt.Errorf("couldn't archive local directory: %w", err)
 	}
 
 	if options.NoUpload {

--- a/internal/local_preview.go
+++ b/internal/local_preview.go
@@ -6,12 +6,10 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/cheggaaa/pb/v3"
-	"github.com/mholt/archiver/v3"
 	ignore "github.com/sabhiram/go-gitignore"
 )
 
@@ -65,16 +63,6 @@ func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []
 		ignoreList = append(ignoreList, ignoreFile)
 	}
 
-	projectRootPrefixes := make(map[string]struct{})
-	if projectRoot != nil {
-		rootPrefix := "."
-		projectRootPrefixes[rootPrefix] = struct{}{}
-		for _, part := range strings.Split(*projectRoot, string(os.PathSeparator)) {
-			rootPrefix = filepath.Join(rootPrefix, part)
-			projectRootPrefixes[rootPrefix] = struct{}{}
-		}
-	}
-
 	customignore := ignore.CompileIgnoreLines(".git", ".terraform")
 	return func(filePath string) bool {
 		if customignore.MatchesPath(filePath) {
@@ -88,10 +76,6 @@ func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []
 		}
 
 		if projectRoot != nil {
-			// We must include all path prefixes of the projectRoot as well.
-			if _, ok := projectRootPrefixes[filePath]; ok {
-				return true
-			}
 			// ensure the root only matches the directory and not all other files
 			root := strings.TrimSuffix(*projectRoot, "/") + "/"
 			if !strings.HasPrefix(filePath, root) {
@@ -101,86 +85,6 @@ func GetIgnoreMatcherFn(ctx context.Context, projectRoot *string, ignoreFiles []
 
 		return true
 	}, nil
-}
-
-// Create a tar.gz of the contents of src at dest. The contents of dest are
-// filtered by the matchFn. To speed up processing of large ignored directories
-// we also short circuit the file system walk if a directory is ignored.
-func CreateArchive(ctx context.Context, src, dest string, matchFn IgnoreMatcherFn) error {
-	if !strings.HasSuffix(dest, ".tar.gz") {
-		return fmt.Errorf(".tar.gz extention required: %s", dest)
-	}
-
-	srcInfo, err := os.Lstat(src)
-	if err != nil {
-		return fmt.Errorf("stat %s, %w", src, err)
-	}
-
-	tgz := *archiver.DefaultTarGz
-
-	destDir := filepath.Dir(dest)
-	err = os.MkdirAll(destDir, 0755)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("%s: mkdir %w", destDir, err)
-		}
-	}
-
-	out, err := os.Create(dest)
-	if err != nil {
-		return fmt.Errorf("creating %s: %w", dest, err)
-	}
-	defer out.Close()
-
-	err = tgz.Create(out)
-	if err != nil {
-		return fmt.Errorf("creating tgz: %w", err)
-	}
-	defer tgz.Close()
-
-	base := filepath.Base(dest)
-	prefixInArchive := strings.TrimSuffix(base, ".tar.gz")
-
-	return filepath.Walk(src, func(fpath string, info os.FileInfo, werr error) error {
-		if werr != nil {
-			return nil
-		}
-
-		if !matchFn(fpath) {
-			if info.Mode().IsDir() {
-				return filepath.SkipDir
-			}
-			if info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-				return nil
-			}
-		}
-		nameInArchive, err := archiver.NameInArchive(srcInfo, src, fpath)
-		if err != nil {
-			return fmt.Errorf("NameInArchive %s: %w", fpath, err)
-		}
-		fullNameInArchive := path.Join(prefixInArchive, nameInArchive)
-		var file io.ReadCloser
-		if info.Mode().IsRegular() {
-			file, err = os.Open(fpath)
-			if err != nil {
-				return fmt.Errorf("%s: open: %w", fpath, err)
-			}
-			defer file.Close()
-		}
-		err = tgz.Write(archiver.File{
-			FileInfo: archiver.FileInfo{
-				FileInfo:   info,
-				CustomName: fullNameInArchive,
-			},
-			FullFilePath: fpath,
-			ReadCloser:   file,
-		})
-		if err != nil {
-			return fmt.Errorf("%s: writing: %w", fpath, err)
-		}
-
-		return nil
-	})
 }
 
 // UploadArchive uploads a tarball to the target endpoint and displays a fancy progress bar.


### PR DESCRIPTION
Fixes: https://github.com/spacelift-io/spacectl/issues/320 by reverting this PR: https://github.com/spacelift-io/spacectl/pull/294

Idea in this PR was nice, but it breaks negations in .terraformignore e.g.
```
*
!some_dir/
```