### PR TITLE
fix: missleading stack not found error

### DIFF
--- a/internal/cmd/authenticated/viewer.go
+++ b/internal/cmd/authenticated/viewer.go
@@ -1,0 +1,28 @@
+package authenticated
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+type Viewer struct {
+	ID   string `graphql:"id" json:"id"`
+	Name string `graphql:"name" json:"name"`
+}
+
+var ErrViewerUnknown = errors.New("failed to query user information: unauthorized")
+
+func CurrentViewer(ctx context.Context) (*Viewer, error) {
+	var query struct {
+		Viewer *Viewer
+	}
+	if err := Client.Query(ctx, &query, map[string]interface{}{}); err != nil {
+		return nil, errors.Wrap(err, "failed to query user information")
+	}
+	if query.Viewer == nil {
+		return nil, ErrViewerUnknown
+	}
+
+	return query.Viewer, nil
+}

--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -187,6 +187,13 @@ func searchStacks[T hasIDAndName](ctx context.Context, input structs.SearchInput
 		return searchStacksResult[T]{}, errors.Wrap(err, "failed search for stacks")
 	}
 
+	if len(query.SearchStacksOutput.Edges) == 0 {
+		_, err := authenticated.CurrentViewer(ctx)
+		if errors.Is(err, authenticated.ErrViewerUnknown) {
+			return searchStacksResult[T]{}, errors.New("You are not logged in, could not find stacks")
+		}
+	}
+
 	stacks := make([]T, 0)
 	for _, q := range query.SearchStacksOutput.Edges {
 		stacks = append(stacks, q.Node)

--- a/internal/cmd/whoami/whoami.go
+++ b/internal/cmd/whoami/whoami.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v3"
 
 	"github.com/spacelift-io/spacectl/client/session"
@@ -29,17 +28,9 @@ func Command() *cli.Command {
 				endpoint = p.Credentials.Endpoint
 			}
 
-			var query struct {
-				Viewer *struct {
-					ID   string `graphql:"id" json:"id"`
-					Name string `graphql:"name" json:"name"`
-				}
-			}
-			if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{}); err != nil {
-				return errors.Wrap(err, "failed to query user information")
-			}
-			if query.Viewer == nil {
-				return errors.New("failed to query user information: unauthorized")
+			query, err := authenticated.CurrentViewer(ctx)
+			if err != nil {
+				return err
 			}
 
 			encoder := json.NewEncoder(os.Stdout)
@@ -49,8 +40,8 @@ func Command() *cli.Command {
 				Name     string `json:"name,omitempty"`
 				Endpoint string `json:"endpoint,omitempty"`
 			}{
-				ID:       query.Viewer.ID,
-				Name:     query.Viewer.Name,
+				ID:       query.ID,
+				Name:     query.Name,
 				Endpoint: endpoint,
 			})
 		},


### PR DESCRIPTION
## Description

Search always returns results for spacectl, making it impossible to know if we have no results or expired credentials. We will now attempt to get info about the user if we got an empty list. This fixes the missleading message.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):



## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed
- [x] All existing tests pass

## Screenshots (if applicable)

<img width="609" alt="image" src="https://github.com/user-attachments/assets/11213406-ff33-472e-8c62-6d78d318339a" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Related Issues

Closes https://github.com/spacelift-io/spacectl/issues/266

