### PR TITLE
feature: add the ability to auto-login

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -62,7 +62,7 @@ func (c *client) determineClientError(ctx context.Context, client *graphql.Clien
 		return fmt.Errorf("unauthorized: You're logged in. Maybe you don't have access to the resource?")
 	}
 
-	return fmt.Errorf("unauthorized: You can re-login using `spacectl profile login`")
+	return fmt.Errorf("unauthorized: You can re-login using `spacectl profile login`, set `SPACELIFT_AUTO_LOGIN=true` for auto-login")
 }
 
 func (c *client) URL(format string, a ...interface{}) string {

--- a/internal/cmd/audittrail/audit_trail.go
+++ b/internal/cmd/audittrail/audit_trail.go
@@ -10,8 +10,9 @@ import (
 // Command returns the audit-trail command subtree.
 func Command() cmd.Command {
 	return cmd.Command{
-		Name:  "audit-trail",
-		Usage: "Manage Spacelift audit trail entries",
+		Name:   "audit-trail",
+		Usage:  "Manage Spacelift audit trail entries",
+		Before: authenticated.AttemptAutoLogin,
 		Versions: []cmd.VersionedCommand{
 			{
 				EarliestVersion: cmd.SupportedVersionAll,

--- a/internal/cmd/authenticated/auto_login.go
+++ b/internal/cmd/authenticated/auto_login.go
@@ -1,0 +1,41 @@
+package authenticated
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+func AttemptAutoLogin(ctx context.Context, _ *cli.Command) (context.Context, error) {
+	autoLogin(ctx)
+	return ctx, nil
+}
+
+func autoLogin(ctx context.Context) {
+	if os.Getenv("SPACELIFT_AUTO_LOGIN") == "" {
+		return
+	}
+
+	ctx, err := Ensure(ctx, nil)
+	if err != nil {
+		fmt.Printf("Error: %s\nFailed to check if logged in, will assume true\n\n", err)
+		return
+	}
+
+	_, err = CurrentViewer(ctx)
+	if err == nil {
+		return
+	}
+	if errors.Is(err, ErrViewerUnknown) {
+		fmt.Println("Attempting auto-login...")
+		if err := LoginCurrentProfile(ctx); err != nil {
+			fmt.Printf("Error: %s\nAuto-login failed, attempt to login manually\n\n", err)
+		}
+		return
+	}
+
+	fmt.Printf("Error: %s\nFailed to check if logged in, will assume true\n\n", err)
+}

--- a/internal/cmd/authenticated/login.go
+++ b/internal/cmd/authenticated/login.go
@@ -1,0 +1,151 @@
+package authenticated
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/pkg/browser"
+	"golang.org/x/term"
+
+	"github.com/spacelift-io/spacectl/browserauth"
+	"github.com/spacelift-io/spacectl/client"
+	"github.com/spacelift-io/spacectl/client/session"
+)
+
+func LoginCurrentProfile(ctx context.Context) error {
+	manager, err := session.UserProfileManager()
+	if err != nil {
+		return fmt.Errorf("could not accesss profile manager: %w", err)
+	}
+
+	profile := manager.Current()
+	if profile == nil {
+		return fmt.Errorf("no current profile set, please use `spacectl profile select <alias>` to select a profile")
+	}
+
+	fmt.Println("===========================================================")
+	fmt.Println("Logging in to the current profile:", profile.Alias)
+	fmt.Println("Detected profile type:", profile.Credentials.Type)
+	fmt.Println("===========================================================")
+
+	storedCredentials := profile.Credentials
+	cfg := &BrowserConfig{}
+	if err := LoginByType(ctx, storedCredentials, cfg); err != nil {
+		return fmt.Errorf("could not login: %w", err)
+	}
+
+	// Check if the credentials are valid before we try persisting them.
+	if _, err := storedCredentials.Session(ctx, client.GetHTTPClient()); err != nil {
+		return fmt.Errorf("credentials look invalid: %w", err)
+	}
+
+	return manager.Create(&session.Profile{
+		Alias:       profile.Alias,
+		Credentials: storedCredentials,
+	})
+}
+
+func LoginByType(ctx context.Context, creds *session.StoredCredentials, browserCfg *BrowserConfig) error {
+	switch creds.Type {
+	case session.CredentialsTypeAPIKey:
+		reader := bufio.NewReader(os.Stdin)
+		if err := LoginUsingAPIKey(reader, creds); err != nil {
+			return err
+		}
+	case session.CredentialsTypeGitHubToken:
+		if err := LoginUsingGitHubAccessToken(creds); err != nil {
+			return err
+		}
+	case session.CredentialsTypeAPIToken:
+		return LoginUsingWebBrowser(ctx, creds, browserCfg)
+	default:
+		return fmt.Errorf("invalid selection (%s), please try again", creds.Type)
+	}
+
+	return nil
+}
+
+func LoginUsingAPIKey(reader *bufio.Reader, creds *session.StoredCredentials) error {
+	fmt.Print("Enter API key ID: ")
+	keyID, err := reader.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	creds.KeyID = strings.TrimSpace(keyID)
+
+	fmt.Print("Enter API key secret: ")
+	keySecret, err := term.ReadPassword(int(syscall.Stdin)) //nolint: unconvert
+	if err != nil {
+		return err
+	}
+	creds.KeySecret = strings.TrimSpace(string(keySecret))
+
+	fmt.Println()
+
+	return nil
+}
+
+func LoginUsingGitHubAccessToken(creds *session.StoredCredentials) error {
+	fmt.Print("Enter GitHub access token: ")
+
+	accessToken, err := term.ReadPassword(int(syscall.Stdin)) //nolint: unconvert
+	if err != nil {
+		return err
+	}
+	creds.AccessToken = strings.TrimSpace(string(accessToken))
+
+	fmt.Println()
+
+	return nil
+}
+
+func LoginUsingWebBrowser(ctx context.Context, creds *session.StoredCredentials, cfg *BrowserConfig) error {
+	handler, err := browserauth.BeginWithBindAddress(creds, cfg.getBindHost(), cfg.getBindPort())
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Waiting for login responses at %s:%d\n", handler.Host, handler.Port)
+	fmt.Printf("\nOpening browser to %s\n\n", handler.AuthenticationURL)
+
+	if err := browser.OpenURL(handler.AuthenticationURL); err != nil {
+		fmt.Printf("Failed to open the browser: %s\nPlease open the URL manually\n\n", err.Error())
+	}
+
+	fmt.Println("Waiting for login...")
+
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	if err := handler.Wait(waitCtx); err != nil {
+		return err
+	}
+
+	fmt.Println("Done!")
+
+	return nil
+}
+
+type BrowserConfig struct {
+	BindHost *string
+	BindPort *int
+}
+
+func (b *BrowserConfig) getBindHost() string {
+	if b.BindHost == nil {
+		return "localhost"
+	}
+	return *b.BindHost
+}
+
+func (b *BrowserConfig) getBindPort() int {
+	if b.BindPort == nil {
+		return 0
+	}
+	return *b.BindPort
+}

--- a/internal/cmd/blueprint/blueprint.go
+++ b/internal/cmd/blueprint/blueprint.go
@@ -14,8 +14,9 @@ import (
 // Command returns the blueprint command subtree.
 func Command() cmd.Command {
 	return cmd.Command{
-		Name:  "blueprint",
-		Usage: "Manage Spacelift blueprints",
+		Name:   "blueprint",
+		Usage:  "Manage Spacelift blueprints",
+		Before: authenticated.AttemptAutoLogin,
 		Versions: []cmd.VersionedCommand{
 			{
 				EarliestVersion: cmd.SupportedVersionAll,

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -32,6 +32,8 @@ type Command struct {
 
 	// Subcommands gets the list of subcommands that support the specified version.
 	Subcommands []Command
+
+	Before cli.BeforeFunc
 }
 
 type VersionedCommand struct {
@@ -105,6 +107,7 @@ func ResolveCommands(instanceVersion SpaceliftInstanceVersion, allCommands []Com
 			latestVersion.Command.Name = command.Name
 			latestVersion.Command.Usage = command.Usage
 			latestVersion.Command.Category = command.Category
+			latestVersion.Command.Before = command.Before
 
 			// Recursively resolve subcommands
 			latestVersion.Command.Commands = resolveSubcommands(instanceVersion, command.Subcommands)

--- a/internal/cmd/mcp/mcp.go
+++ b/internal/cmd/mcp/mcp.go
@@ -14,8 +14,9 @@ import (
 // Command returns the MCP command subtree.
 func Command() cmd.Command {
 	return cmd.Command{
-		Name:  "mcp",
-		Usage: "Manage MCP server",
+		Name:   "mcp",
+		Usage:  "Manage MCP server",
+		Before: authenticated.AttemptAutoLogin,
 		Versions: []cmd.VersionedCommand{
 			{
 				EarliestVersion: cmd.SupportedVersionAll,

--- a/internal/cmd/module/module.go
+++ b/internal/cmd/module/module.go
@@ -17,6 +17,7 @@ func Command() cmd.Command {
 				Command:         &cli.Command{},
 			},
 		},
+		Before: authenticated.AttemptAutoLogin,
 		Subcommands: []cmd.Command{
 			{
 				Category: "Module management",

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -10,8 +10,9 @@ import (
 // Command returns the versioned policy command subtree.
 func Command() cmd.Command {
 	return cmd.Command{
-		Name:  "policy",
-		Usage: "Manage Spacelift policies",
+		Name:   "policy",
+		Usage:  "Manage Spacelift policies",
+		Before: authenticated.AttemptAutoLogin,
 		Versions: []cmd.VersionedCommand{
 			{
 				EarliestVersion: cmd.SupportedVersionAll,

--- a/internal/cmd/provider/provider.go
+++ b/internal/cmd/provider/provider.go
@@ -18,6 +18,7 @@ func Command() cmd.Command {
 				Command:         &cli.Command{},
 			},
 		},
+		Before: authenticated.AttemptAutoLogin,
 		Subcommands: []cmd.Command{
 			{
 				Category: "GPG key management",

--- a/internal/cmd/run_external_dependency/run_external_dependency.go
+++ b/internal/cmd/run_external_dependency/run_external_dependency.go
@@ -10,8 +10,9 @@ import (
 // Command encapsulates the run external dependency command subtree.
 func Command() cmd.Command {
 	return cmd.Command{
-		Name:  "run-external-dependency",
-		Usage: "Manage Spacelift Run external dependencies",
+		Name:   "run-external-dependency",
+		Usage:  "Manage Spacelift Run external dependencies",
+		Before: authenticated.AttemptAutoLogin,
 		Versions: []cmd.VersionedCommand{
 			{
 				EarliestVersion: cmd.SupportedVersionAll,

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -18,6 +18,7 @@ func Command() cmd.Command {
 				Command:         &cli.Command{},
 			},
 		},
+		Before: authenticated.AttemptAutoLogin,
 		Subcommands: []cmd.Command{
 			{
 				Category: "Run management",

--- a/internal/cmd/workerpools/cmd.go
+++ b/internal/cmd/workerpools/cmd.go
@@ -10,8 +10,9 @@ import (
 // Command encapsulates the workerpool command subtree.
 func Command() cmd.Command {
 	return cmd.Command{
-		Name:  "workerpool",
-		Usage: "Manages workerpools and their workers.",
+		Name:   "workerpool",
+		Usage:  "Manages workerpools and their workers.",
+		Before: authenticated.AttemptAutoLogin,
 		Versions: []cmd.VersionedCommand{
 			{
 				EarliestVersion: cmd.SupportedVersionAll,


### PR DESCRIPTION
## Description

This feature is opt-in by default so as to not break any API or disturb any scripts. An EVN variable must be specified for it work. Here is example on how it works:

```
➜  spacectl git:(main) ✗ spc profile select preprod-me
➜  spacectl git:(main) ✗ spc stack list
===========================================================
Logging in to the current profile: preprod-me
Detected profile type: API Token
===========================================================
Waiting for login responses at 127.0.0.1:60360

Opening browser to https://tomasmik.app.spacelift.dev/
````

When user is not logged in, we will alert them about this feature, so they can enable it.
If anything fails, we assume the user is logged in an allow for further commands to be called. This eliminates any false positives that would block the user. 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Screenshots (if applicable)

Add screenshots to show visual changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings

## Related Issues

Closes #(issue number)
Fixes #(issue number)
Related to #(issue number)
