### PR TITLE
Fix: Don't always override the `TF_CLI_ARGS_plan`

### DIFF
--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -161,10 +161,12 @@ func createLocalPreviewRun(
 		val = strings.Join([]string{val, "-target=" + v}, " ")
 	}
 
-	envVars = append(envVars, EnvironmentVariable{
-		Key:   "TF_CLI_ARGS_plan",
-		Value: graphql.String(strings.TrimSpace(val)),
-	})
+	if len(options.Targets) > 0 {
+		envVars = append(envVars, EnvironmentVariable{
+			Key:   "TF_CLI_ARGS_plan",
+			Value: graphql.String(strings.TrimSpace(val)),
+		})
+	}
 
 	packagePath := options.Path
 	if options.FindRepositoryRoot {


### PR DESCRIPTION

## Description

Some customers want to use this `TF_CLI_ARGS_plan` variable, we should allow that and not override it if no targets were provided.

https://spacelift-io.slack.com/archives/C036ERF1VRU/p1751552717189209?thread_ts=1751387267.618059&cid=C036ERF1VRU

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- List the main changes
- Include any important details
- Mention files or components affected

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Screenshots (if applicable)

Add screenshots to show visual changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings

## Related Issues

Closes #(issue number)
Fixes #(issue number)
Related to #(issue number)
