### PR TITLE
Allows the "spacectl stack logs" command to exit after logs are retrieved

### DIFF
--- a/internal/cmd/stack/run_logs.go
+++ b/internal/cmd/stack/run_logs.go
@@ -111,6 +111,7 @@ func runStates(ctx context.Context, stack, run string, sink chan<- string, acFn 
 		}
 
 		history := query.Stack.Run.History
+		processedNewState := false
 
 		for index := range history {
 			// Unlike the GUI, we go earliest first.
@@ -120,6 +121,7 @@ func runStates(ctx context.Context, stack, run string, sink chan<- string, acFn 
 				continue
 			}
 			backoff = 0
+			processedNewState = true
 			reportedStates[transition.State] = struct{}{}
 
 			sink <- fmt.Sprintf(`
@@ -144,6 +146,10 @@ func runStates(ctx context.Context, stack, run string, sink chan<- string, acFn 
 			if transition.Terminal {
 				return &transition, nil
 			}
+		}
+
+		if !processedNewState && backoff > 0 {
+			return nil, nil
 		}
 
 		time.Sleep(backoff * time.Second)


### PR DESCRIPTION
## Description

Currently, the `spacectl stack logs` command will hang after it fetches the logs for a run. This is an issue when working with the CLI programmatically as the program will never exit. This change detects when the CLI has fetched all the available logs and returns the function. 

Note: I have tested these changes locally for my use case of getting logs for already completed runs. I am unsure of the effects on other uses of this function.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- List the main changes
- Include any important details
- Mention files or components affected

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
