### PR TITLE
Allow to filter logs by a specific state

### DIFF
--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -172,3 +172,8 @@ var flagWithGitDir = &cli.BoolFlag{
 	Name:  "with-git-dir",
 	Usage: "[Optional] Add the .git to the archive, useful when you define custom behavior inside the repository",
 }
+
+var flagPhase = &cli.StringFlag{
+	Name:  "phase",
+	Usage: "[Optional] Only show logs for a specific `PHASE` (e.g., QUEUED, PREPARING, PLANNING, APPLYING, FINISHED)",
+}

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -308,6 +308,7 @@ func Command() cmd.Command {
 								flagStackID,
 								flagRun,
 								flagRunLatest,
+								flagPhase,
 							},
 							Action:    runLogs,
 							Before:    authenticated.Ensure,


### PR DESCRIPTION
## Description

You can now filter for a specific phase.

```
✗ ./spacectl stack logs --run 01K5GXE96JWC8DP35K0G71479N --phase preparing
[Ground Control] This is Ground Control to public worker 01K5EWTAF02GWSS5KYB0KD97QX, commencing countdown
[Ground Control] No initialization policies attached
[Ground Control] Creating metadata...
[Ground Control] Uploading metadata...
....
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


Closes https://github.com/spacelift-io/spacectl/issues/344

