### PR TITLE
Re-read user session and refresh token when using MCP

### DIFF
--- a/internal/cmd/audittrail/list.go
+++ b/internal/cmd/audittrail/list.go
@@ -182,7 +182,7 @@ func searchAuditTrailEntries(ctx context.Context, input structs.SearchInput) (se
 		} `graphql:"searchAuditTrailEntries(input: $input)"`
 	}
 
-	if err := authenticated.Client.Query(
+	if err := authenticated.Client().Query(
 		ctx,
 		&query,
 		map[string]interface{}{"input": input},

--- a/internal/cmd/authenticated/viewer.go
+++ b/internal/cmd/authenticated/viewer.go
@@ -17,7 +17,7 @@ func CurrentViewer(ctx context.Context) (*Viewer, error) {
 	var query struct {
 		Viewer *Viewer
 	}
-	if err := Client.Query(ctx, &query, map[string]interface{}{}); err != nil {
+	if err := Client().Query(ctx, &query, map[string]interface{}{}); err != nil {
 		return nil, errors.Wrap(err, "failed to query user information")
 	}
 	if query.Viewer == nil {

--- a/internal/cmd/blueprint/deploy.go
+++ b/internal/cmd/blueprint/deploy.go
@@ -77,7 +77,7 @@ func (c *deployCommand) deploy(ctx context.Context, cliCmd *cli.Command) error {
 		} `graphql:"blueprintCreateStack(id: $id, input: $input)"`
 	}
 
-	err = authenticated.Client.Mutate(
+	err = authenticated.Client().Mutate(
 		ctx,
 		&mutation,
 		map[string]any{
@@ -91,7 +91,7 @@ func (c *deployCommand) deploy(ctx context.Context, cliCmd *cli.Command) error {
 		return fmt.Errorf("failed to deploy stack from the blueprint: %w", err)
 	}
 
-	url := authenticated.Client.URL("/stack/%s", mutation.BlueprintCreateStack.StackID)
+	url := authenticated.Client().URL("/stack/%s", mutation.BlueprintCreateStack.StackID)
 	fmt.Printf("\nCreated stack: %q", url)
 
 	return nil

--- a/internal/cmd/blueprint/list.go
+++ b/internal/cmd/blueprint/list.go
@@ -207,7 +207,7 @@ func searchBlueprints(ctx context.Context, input structs.SearchInput) (searchBlu
 		} `graphql:"searchBlueprints(input: $input)"`
 	}
 
-	if err := authenticated.Client.Query(
+	if err := authenticated.Client().Query(
 		ctx,
 		&query,
 		map[string]interface{}{"input": input},

--- a/internal/cmd/blueprint/show.go
+++ b/internal/cmd/blueprint/show.go
@@ -164,7 +164,7 @@ func getBlueprintByID(ctx context.Context, blueprintID string) (blueprint, bool,
 		"blueprintId": graphql.ID(blueprintID),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return blueprint{}, false, errors.Wrapf(err, "failed to query for blueprint ID %q", blueprintID)
 	}
 

--- a/internal/cmd/draw/data/workerpools.go
+++ b/internal/cmd/draw/data/workerpools.go
@@ -21,7 +21,7 @@ type WorkerPool struct {
 
 // Selected opens the selected worker pool in the browser.
 func (q *WorkerPool) Selected(row table.Row) error {
-	return browser.OpenURL(authenticated.Client.URL("/stack/%s/run/%s", row[1], row[2]))
+	return browser.OpenURL(authenticated.Client().URL("/stack/%s/run/%s", row[1], row[2]))
 }
 
 // Columns returns the columns of the worker pool table.
@@ -73,7 +73,7 @@ func (q *WorkerPool) getPublicPoolRuns(ctx context.Context) ([]runsEdge, error) 
 		} `graphql:"publicWorkerPool"`
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, q.baseSearchParams()); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, q.baseSearchParams()); err != nil {
 		return nil, errors.Wrap(err, "failed to query run list")
 	}
 
@@ -90,7 +90,7 @@ func (q *WorkerPool) getPrivatePoolRuns(ctx context.Context) ([]runsEdge, error)
 	vars := q.baseSearchParams()
 	vars["id"] = q.WokerPoolID
 
-	if err := authenticated.Client.Query(ctx, &query, vars); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, vars); err != nil {
 		return nil, errors.Wrap(err, "failed to query run list")
 	}
 

--- a/internal/cmd/graphql/mcp.go
+++ b/internal/cmd/graphql/mcp.go
@@ -38,6 +38,7 @@ func registerIntrospectSchemaTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(introspectTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		format := request.GetString("format", "summary")
 
 		var query struct {
@@ -120,7 +121,7 @@ func registerIntrospectSchemaTool(s *server.MCPServer) {
 			} `graphql:"__schema"`
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, map[string]any{}); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, map[string]any{}); err != nil {
 			return nil, errors.Wrap(err, "failed to introspect GraphQL schema")
 		}
 
@@ -144,6 +145,7 @@ func registerGetTypeDetailsTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(typeDetailsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		typeName, err := request.RequireString("type_name")
 		if err != nil {
 			return nil, err
@@ -191,7 +193,7 @@ func registerGetTypeDetailsTool(s *server.MCPServer) {
 			} `graphql:"__type(name: $name)"`
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, map[string]any{"name": graphql.String(typeName)}); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, map[string]any{"name": graphql.String(typeName)}); err != nil {
 			return nil, errors.Wrap(err, "failed to get type details")
 		}
 
@@ -223,6 +225,7 @@ func registerSearchSchemaFieldsTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(searchTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		searchTerm, err := request.RequireString("search_term")
 		if err != nil {
 			return nil, err
@@ -271,7 +274,7 @@ func registerSearchSchemaFieldsTool(s *server.MCPServer) {
 			} `graphql:"__schema"`
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, map[string]any{}); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, map[string]any{}); err != nil {
 			return nil, errors.Wrap(err, "failed to introspect GraphQL schema")
 		}
 
@@ -505,6 +508,7 @@ func registerAuthenticationGuideTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(authTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		authMethod := request.GetString("auth_method", "all")
 
 		var guide strings.Builder

--- a/internal/cmd/module/create_version.go
+++ b/internal/cmd/module/create_version.go
@@ -37,7 +37,7 @@ func createVersion(ctx context.Context, cliCmd *cli.Command) error {
 		"version":   version,
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 

--- a/internal/cmd/module/delete_version.go
+++ b/internal/cmd/module/delete_version.go
@@ -25,7 +25,7 @@ func deleteVersion(ctx context.Context, cliCmd *cli.Command) error {
 		"module": graphql.ID(moduleID),
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 

--- a/internal/cmd/module/list.go
+++ b/internal/cmd/module/list.go
@@ -212,7 +212,7 @@ func searchModules(ctx context.Context, input structs.SearchInput) (searchModule
 		} `graphql:"searchModules(input: $input)"`
 	}
 
-	if err := authenticated.Client.Query(
+	if err := authenticated.Client().Query(
 		ctx,
 		&query,
 		map[string]interface{}{"input": input},

--- a/internal/cmd/module/local_preview.go
+++ b/internal/cmd/module/local_preview.go
@@ -62,7 +62,7 @@ func localPreviewFunc(useHeaders bool) cli.ActionFunc {
 				UploadLocalWorkspace headersResponse `graphql:"uploadLocalWorkspace(stack: $stack)"`
 			}
 
-			if err := authenticated.Client.Mutate(ctx, &headersMutation, uploadVariables); err != nil {
+			if err := authenticated.Client().Mutate(ctx, &headersMutation, uploadVariables); err != nil {
 				return err
 			}
 
@@ -75,7 +75,7 @@ func localPreviewFunc(useHeaders bool) cli.ActionFunc {
 				UploadLocalWorkspace basicResponse `graphql:"uploadLocalWorkspace(stack: $stack)"`
 			}
 
-			if err := authenticated.Client.Mutate(ctx, &basicMutation, uploadVariables); err != nil {
+			if err := authenticated.Client().Mutate(ctx, &basicMutation, uploadVariables); err != nil {
 				return err
 			}
 
@@ -136,7 +136,7 @@ func localPreviewFunc(useHeaders bool) cli.ActionFunc {
 			requestOpts = append(requestOpts, graphql.WithHeader(internal.UserProvidedRunMetadataHeader, cliCmd.String(flagRunMetadata.Name)))
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &triggerMutation, triggerVariables, requestOpts...); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &triggerMutation, triggerVariables, requestOpts...); err != nil {
 			return err
 		}
 
@@ -158,7 +158,7 @@ func localPreviewFunc(useHeaders bool) cli.ActionFunc {
 							} `graphql:"module(id: $module)"`
 						}
 
-						if err := authenticated.Client.Query(ctx, &getRun, map[string]interface{}{
+						if err := authenticated.Client().Query(ctx, &getRun, map[string]interface{}{
 							"module": graphql.ID(moduleID),
 							"run":    graphql.ID(triggerMutation.VersionProposeLocalWorkspace[index].ID),
 						}); err != nil {
@@ -306,7 +306,7 @@ func (m *moduleLocalPreviewModel) View() (s string) {
 		if m.Runs[i].Finished {
 			spinnerView = "⠿"
 		}
-		s += fmt.Sprintf(" %s %s • %s • %s\n", spinnerView, styledState(m.Runs[i].State), m.Runs[i].Title, authenticated.Client.URL(
+		s += fmt.Sprintf(" %s %s • %s • %s\n", spinnerView, styledState(m.Runs[i].State), m.Runs[i].Title, authenticated.Client().URL(
 			"/module/%s/run/%s",
 			m.ModuleID,
 			m.Runs[i].ID,

--- a/internal/cmd/module/mcp.go
+++ b/internal/cmd/module/mcp.go
@@ -39,6 +39,7 @@ func registerModuleGuideTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(moduleGuideTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		topic := request.GetString("topic", "all")
 
 		var guide strings.Builder
@@ -174,6 +175,7 @@ func registerListModulesTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(modulesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		limit := request.GetInt("limit", 50)
 
 		var fullTextSearch *graphql.String
@@ -231,6 +233,7 @@ func registerGetModuleTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(moduleTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		moduleID, err := request.RequireString("module_id")
 		if err != nil {
 			return nil, err
@@ -240,7 +243,7 @@ func registerGetModuleTool(s *server.MCPServer) {
 			Module *moduleDetailQuery `graphql:"module(id: $moduleId)"`
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, map[string]any{"moduleId": moduleID}); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, map[string]any{"moduleId": moduleID}); err != nil {
 			return nil, errors.Wrap(err, "failed to query module")
 		}
 
@@ -270,6 +273,7 @@ func registerListModuleVersionsTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(moduleVersionsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		moduleID, err := request.RequireString("module_id")
 		if err != nil {
 			return nil, err
@@ -290,7 +294,7 @@ func registerListModuleVersionsTool(s *server.MCPServer) {
 			"includeFailed": includeFailed,
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 			return nil, errors.Wrap(err, "failed to query module versions")
 		}
 
@@ -345,7 +349,7 @@ func registerGetModuleVersionTool(s *server.MCPServer) {
 			"versionId": versionID,
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 			return nil, errors.Wrap(err, "failed to query module version")
 		}
 
@@ -596,7 +600,7 @@ func searchModulesMCP(ctx context.Context, input structs.SearchInput) (*mcpSearc
 
 	variables := map[string]any{"input": input}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return nil, errors.Wrap(err, "failed to execute modules search query")
 	}
 

--- a/internal/cmd/module/search_version.go
+++ b/internal/cmd/module/search_version.go
@@ -102,7 +102,7 @@ func getSearchModuleVersions(ctx context.Context, cliCmd *cli.Command, cursor st
 		after = graphql.NewString(graphql.String(cursor))
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{
+	if err := authenticated.Client().Query(ctx, &query, map[string]interface{}{
 		"id": cliCmd.String(flagModuleID.Name),
 		"input": structs.SearchInput{
 			First: graphql.NewInt(graphql.Int(int32(limit))), //nolint: gosec

--- a/internal/cmd/policy/list.go
+++ b/internal/cmd/policy/list.go
@@ -187,7 +187,7 @@ func searchPolicies(ctx context.Context, input structs.SearchInput) (searchPolic
 		} `graphql:"searchPolicies(input: $input)"`
 	}
 
-	if err := authenticated.Client.Query(
+	if err := authenticated.Client().Query(
 		ctx,
 		&query,
 		map[string]interface{}{"input": input},

--- a/internal/cmd/policy/mcp.go
+++ b/internal/cmd/policy/mcp.go
@@ -36,6 +36,7 @@ func registerListPoliciesTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(policiesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		limit := request.GetInt("limit", 50)
 
 		var fullTextSearch *graphql.String
@@ -93,6 +94,7 @@ func registerGetPolicyTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(policyTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		policyID, err := request.RequireString("policy_id")
 		if err != nil {
 			return nil, err
@@ -127,6 +129,7 @@ func registerListPolicySamplesTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(samplesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		policyID, err := request.RequireString("policy_id")
 		if err != nil {
 			return nil, err
@@ -140,7 +143,7 @@ func registerListPolicySamplesTool(s *server.MCPServer) {
 			"policyId": graphql.ID(policyID),
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 			return nil, errors.Wrapf(err, "failed to query for policy ID %q", policyID)
 		}
 
@@ -174,6 +177,7 @@ func registerGetPolicySampleTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(sampleTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		policyID, err := request.RequireString("policy_id")
 		if err != nil {
 			return nil, err
@@ -195,7 +199,7 @@ func registerGetPolicySampleTool(s *server.MCPServer) {
 			"key":      graphql.String(sampleKey),
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 			return nil, errors.Wrapf(err, "failed to query for policy sample")
 		}
 
@@ -227,6 +231,7 @@ func registerListPolicySamplesIndexedTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(samplesIndexedTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		policyID, err := request.RequireString("policy_id")
 		if err != nil {
 			return nil, err

--- a/internal/cmd/policy/sample.go
+++ b/internal/cmd/policy/sample.go
@@ -42,7 +42,7 @@ func (c *sampleCommand) getSamplesPolicyByID(ctx context.Context, policyID, key 
 		"key":      graphql.String(key),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return policyEvaluationSample{}, errors.Wrapf(err, "failed to query for policyEvaluation ID %q", policyID)
 	}
 

--- a/internal/cmd/policy/samples.go
+++ b/internal/cmd/policy/samples.go
@@ -59,7 +59,7 @@ func (c *samplesCommand) getSamplesPolicyByID(ctx context.Context, policyID stri
 		"policyId": graphql.ID(policyID),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return policyEvaluation{}, false, errors.Wrapf(err, "failed to query for policyEvaluation ID %q", policyID)
 	}
 

--- a/internal/cmd/policy/samples_indexed.go
+++ b/internal/cmd/policy/samples_indexed.go
@@ -209,7 +209,7 @@ func searchEvaluationRecords(ctx context.Context, policyID string, input structs
 		"input": input,
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return searchEvaluationRecordsResult{}, errors.Wrap(err, "failed to search evaluation records")
 	}
 

--- a/internal/cmd/policy/show.go
+++ b/internal/cmd/policy/show.go
@@ -70,7 +70,7 @@ func getPolicyByID(ctx context.Context, policyID string) (policy, bool, error) {
 		"policyId": graphql.ID(policyID),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return policy{}, false, errors.Wrapf(err, "failed to query for policy ID %q", policyID)
 	}
 

--- a/internal/cmd/policy/simulate.go
+++ b/internal/cmd/policy/simulate.go
@@ -44,7 +44,7 @@ func (c *simulateCommand) simulate(ctx context.Context, cliCmd *cli.Command) err
 		"type":  b.Type,
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 

--- a/internal/cmd/profile/usage_view_csv_command.go
+++ b/internal/cmd/profile/usage_view_csv_command.go
@@ -47,7 +47,7 @@ func usageViewCsv(ctx context.Context, cliCmd *cli.Command) error {
 
 	// execute http query
 	fmt.Fprint(os.Stderr, "Querying Spacelift for usage data...\n")
-	resp, err := authenticated.Client.Do(req)
+	resp, err := authenticated.Client().Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/provider/add_gpg_key.go
+++ b/internal/cmd/provider/add_gpg_key.go
@@ -47,7 +47,7 @@ func addGPGKey() cli.ActionFunc {
 			"asciiArmor": graphql.String(asciiArmor),
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return err
 		}
 

--- a/internal/cmd/provider/create_version.go
+++ b/internal/cmd/provider/create_version.go
@@ -81,7 +81,7 @@ func createVersion(useHeadersFromAPI bool) cli.ActionFunc {
 				} `graphql:"terraformProviderVersionCreate(provider: $provider, input: $input)"`
 			}
 
-			if err := authenticated.Client.Mutate(ctx, &createMutation, variables); err != nil {
+			if err := authenticated.Client().Mutate(ctx, &createMutation, variables); err != nil {
 				return err
 			}
 
@@ -103,7 +103,7 @@ func createVersion(useHeadersFromAPI bool) cli.ActionFunc {
 				} `graphql:"terraformProviderVersionCreate(provider: $provider, input: $input)"`
 			}
 
-			if err := authenticated.Client.Mutate(ctx, &createMutation, variables); err != nil {
+			if err := authenticated.Client().Mutate(ctx, &createMutation, variables); err != nil {
 				return err
 			}
 
@@ -161,7 +161,7 @@ func createVersion(useHeadersFromAPI bool) cli.ActionFunc {
 
 		fmt.Println("Uploading the changelog")
 
-		if err := authenticated.Client.Mutate(ctx, &changelogMutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &changelogMutation, variables); err != nil {
 			return errors.Wrap(err, "could not update changelog")
 		}
 
@@ -192,7 +192,7 @@ func registerPlatform(ctx context.Context, dir string, versionID string, artifac
 		},
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 
@@ -233,7 +233,7 @@ func registerPlatformV2(ctx context.Context, dir string, versionID string, artif
 		},
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 

--- a/internal/cmd/provider/delete_version.go
+++ b/internal/cmd/provider/delete_version.go
@@ -21,7 +21,7 @@ func deleteVersion() cli.ActionFunc {
 
 		variables := map[string]any{"version": graphql.ID(versionID)}
 
-		if err := authenticated.Client.Mutate(ctx, &deleteMutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &deleteMutation, variables); err != nil {
 			return fmt.Errorf("could not delete Terraform provider version: %w", err)
 		}
 

--- a/internal/cmd/provider/list_gpg_keys.go
+++ b/internal/cmd/provider/list_gpg_keys.go
@@ -22,7 +22,7 @@ func listGPGKeys() cli.ActionFunc {
 			GPGKeys internal.GPGKeys `graphql:"gpgKeys"`
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, nil); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, nil); err != nil {
 			return err
 		}
 

--- a/internal/cmd/provider/list_versions.go
+++ b/internal/cmd/provider/list_versions.go
@@ -28,7 +28,7 @@ func listVersions() cli.ActionFunc {
 		providerType := cliCmd.String(flagProviderType.Name)
 
 		variables := map[string]any{"id": graphql.ID(providerType)}
-		if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 			return fmt.Errorf("could not list Terraform provider versions: %w", err)
 		}
 

--- a/internal/cmd/provider/publish_version.go
+++ b/internal/cmd/provider/publish_version.go
@@ -21,7 +21,7 @@ func publishVersion() cli.ActionFunc {
 
 		variables := map[string]any{"version": graphql.ID(versionID)}
 
-		if err := authenticated.Client.Mutate(ctx, &publishMutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &publishMutation, variables); err != nil {
 			return fmt.Errorf("could not publish Terraform provider version: %w", err)
 		}
 

--- a/internal/cmd/provider/revoke_gpg_key.go
+++ b/internal/cmd/provider/revoke_gpg_key.go
@@ -20,7 +20,7 @@ func revokeGPGKey() cli.ActionFunc {
 
 		variables := map[string]any{"id": keyID}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return err
 		}
 

--- a/internal/cmd/provider/revoke_version.go
+++ b/internal/cmd/provider/revoke_version.go
@@ -21,7 +21,7 @@ func revokeVersion() cli.ActionFunc {
 
 		variables := map[string]any{"version": graphql.ID(versionID)}
 
-		if err := authenticated.Client.Mutate(ctx, &revokeMutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &revokeMutation, variables); err != nil {
 			return fmt.Errorf("could not revoke Terraform provider version: %w", err)
 		}
 

--- a/internal/cmd/run_external_dependency/mark_completed.go
+++ b/internal/cmd/run_external_dependency/mark_completed.go
@@ -31,7 +31,7 @@ func markRunExternalDependencyAsCompleted(ctx context.Context, cliCmd *cli.Comma
 		"status":     RunExternalDependencyStatus(strings.ToUpper(status)),
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 

--- a/internal/cmd/stack/delete.go
+++ b/internal/cmd/stack/delete.go
@@ -65,7 +65,7 @@ func deleteStack() cli.ActionFunc {
 			"destroyResources": graphql.Boolean(destroyResources),
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return err
 		}
 

--- a/internal/cmd/stack/dependencies.go
+++ b/internal/cmd/stack/dependencies.go
@@ -65,7 +65,7 @@ func dependenciesListOneStack(ctx context.Context, cliCmd *cli.Command) (*stackW
 	}
 
 	variables := map[string]any{"id": graphql.ID(id)}
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return nil, errors.Wrap(err, "failed to query one stack")
 	}
 

--- a/internal/cmd/stack/enable.go
+++ b/internal/cmd/stack/enable.go
@@ -48,5 +48,5 @@ func enableDisable[T any](ctx context.Context, cliCmd *cli.Command) error {
 		"stack": graphql.ID(stackID),
 	}
 
-	return authenticated.Client.Mutate(ctx, &mutation, variables)
+	return authenticated.Client().Mutate(ctx, &mutation, variables)
 }

--- a/internal/cmd/stack/environment.go
+++ b/internal/cmd/stack/environment.go
@@ -113,7 +113,7 @@ func setVar(ctx context.Context, cliCmd *cli.Command) error {
 		},
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 
@@ -144,7 +144,7 @@ func (e *listEnvCommand) listEnv(ctx context.Context, cliCmd *cli.Command) error
 		"stack": graphql.ID(stackID),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return err
 	}
 
@@ -327,7 +327,7 @@ func mountFile(ctx context.Context, cliCmd *cli.Command) error {
 		},
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 
@@ -360,7 +360,7 @@ func deleteEnvironment(ctx context.Context, cliCmd *cli.Command) error {
 		"id":    graphql.ID(envName),
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -32,7 +32,7 @@ func localPreview(useHeaders bool) cli.ActionFunc {
 		}
 
 		if !stack.LocalPreviewEnabled {
-			linkToStack := authenticated.Client.URL("/stack/%s", stack.ID)
+			linkToStack := authenticated.Client().URL("/stack/%s", stack.ID)
 			return fmt.Errorf("local preview has not been enabled for this stack, please enable local preview in the stack settings: %s", linkToStack)
 		}
 
@@ -73,7 +73,7 @@ func localPreview(useHeaders bool) cli.ActionFunc {
 			return fmt.Errorf("failed to create local preview run: %w", err)
 		}
 
-		linkToRun := authenticated.Client.URL(
+		linkToRun := authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stack.ID,
 			runID,
@@ -211,7 +211,7 @@ func createLocalPreviewRun(
 			UploadLocalWorkspace headersResponse `graphql:"uploadLocalWorkspace(stack: $stack)"`
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &headersMutation, uploadVariables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &headersMutation, uploadVariables); err != nil {
 			return "", fmt.Errorf("failed to upload local workspace: %w", err)
 		}
 
@@ -224,7 +224,7 @@ func createLocalPreviewRun(
 			UploadLocalWorkspace basicResponse `graphql:"uploadLocalWorkspace(stack: $stack)"`
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &basicMutation, uploadVariables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &basicMutation, uploadVariables); err != nil {
 			return "", fmt.Errorf("failed to upload local workspace: %w", err)
 		}
 
@@ -284,7 +284,7 @@ func createLocalPreviewRun(
 	}
 
 	fmt.Fprintln(writer, "Creating local preview run...")
-	if err = authenticated.Client.Mutate(ctx, &triggerMutation, triggerVariables, requestOpts...); err != nil {
+	if err = authenticated.Client().Mutate(ctx, &triggerMutation, triggerVariables, requestOpts...); err != nil {
 		return "", err
 	}
 

--- a/internal/cmd/stack/lock.go
+++ b/internal/cmd/stack/lock.go
@@ -44,7 +44,7 @@ func lock(ctx context.Context, cliCmd *cli.Command) error {
 		"note":  graphql.String(note),
 	}
 
-	return authenticated.Client.Mutate(ctx, &mutation, variables)
+	return authenticated.Client().Mutate(ctx, &mutation, variables)
 }
 
 func unlock(ctx context.Context, cliCmd *cli.Command) error {
@@ -62,5 +62,5 @@ func unlock(ctx context.Context, cliCmd *cli.Command) error {
 		"stack": graphql.ID(stackID),
 	}
 
-	return authenticated.Client.Mutate(ctx, &mutation, variables)
+	return authenticated.Client().Mutate(ctx, &mutation, variables)
 }

--- a/internal/cmd/stack/mcp.go
+++ b/internal/cmd/stack/mcp.go
@@ -49,6 +49,7 @@ func registerListStacksTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stacksTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		limit := request.GetInt("limit", 50)
 
 		var fullTextSearch *graphql.String
@@ -107,6 +108,7 @@ func registerListStackRunsTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stackRunsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -123,7 +125,7 @@ func registerListStackRunsTool(s *server.MCPServer) {
 			} `graphql:"stack(id: $stackId)"`
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
 			return nil, errors.Wrap(err, "failed to query run list")
 		}
 		if query.Stack == nil {
@@ -166,6 +168,7 @@ func registerListStackProposedRunsTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stackRunsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -182,7 +185,7 @@ func registerListStackProposedRunsTool(s *server.MCPServer) {
 			} `graphql:"stack(id: $stackId)"`
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, map[string]any{"stackId": stackID, "before": before}); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, map[string]any{"stackId": stackID, "before": before}); err != nil {
 			return nil, errors.Wrap(err, "failed to query run list")
 		}
 		if query.Stack == nil {
@@ -225,6 +228,7 @@ func registerGetStackRunTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stackRunsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -241,7 +245,7 @@ func registerGetStackRunTool(s *server.MCPServer) {
 			} `graphql:"stack(id: $stackId)"`
 		}
 
-		if err := authenticated.Client.Query(ctx, &query, map[string]any{"stackId": stackID, "runId": runID}); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, map[string]any{"stackId": stackID, "runId": runID}); err != nil {
 			return nil, errors.Wrap(err, "failed to query run list")
 		}
 		if query.Stack == nil {
@@ -278,6 +282,7 @@ func registerGetStackRunLogsTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stackRunLogsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -372,6 +377,7 @@ func registerGetStackRunChangesTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stackRunChangesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -414,6 +420,7 @@ func registerTriggerStackRunTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stackRunTriggerTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -438,12 +445,12 @@ func registerTriggerStackRunTool(s *server.MCPServer) {
 			variables["sha"] = graphql.NewString(graphql.String(commitSha))
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return nil, errors.Wrap(err, "failed to trigger run")
 		}
 
 		output := fmt.Sprintf("Successfully created a %s\n", runType)
-		output += fmt.Sprintf("The live run can be visited at %s", authenticated.Client.URL(
+		output += fmt.Sprintf("The live run can be visited at %s", authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunTrigger.ID,
@@ -464,6 +471,7 @@ func registerDiscardStackRunTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stackRunDiscardTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -485,12 +493,12 @@ func registerDiscardStackRunTool(s *server.MCPServer) {
 			"run":   graphql.ID(runID),
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return nil, errors.Wrap(err, "failed to discard run")
 		}
 
 		output := "You have successfully discarded a deployment\n"
-		output += fmt.Sprintf("The run can be visited at %s", authenticated.Client.URL(
+		output += fmt.Sprintf("The run can be visited at %s", authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunDiscard.ID,
@@ -511,6 +519,7 @@ func registerConfirmStackRunTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(stackRunConfirmTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -532,12 +541,12 @@ func registerConfirmStackRunTool(s *server.MCPServer) {
 			"run":   graphql.ID(runID),
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return nil, errors.Wrap(err, "failed to confirm run")
 		}
 
 		output := "You have successfully confirmed a deployment\n"
-		output += fmt.Sprintf("The live run can be visited at %s", authenticated.Client.URL(
+		output += fmt.Sprintf("The live run can be visited at %s", authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunConfirm.ID,
@@ -558,6 +567,7 @@ func registerListResourcesTool(s *server.MCPServer) {
 	)
 
 	s.AddTool(resourcesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		if stackID := request.GetString("stack_id", ""); stackID != "" {
 			return listResourcesForOneStack(ctx, stackID)
 		}
@@ -585,6 +595,7 @@ func registerLocalPreviewTool(s *server.MCPServer, options McpOptions) {
 	)
 
 	s.AddTool(localPreviewTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		authenticated.Ensure(ctx, nil)
 		stackID, err := request.RequireString("stack_id")
 		if err != nil {
 			return nil, err
@@ -599,7 +610,7 @@ func registerLocalPreviewTool(s *server.MCPServer, options McpOptions) {
 		}
 
 		if !stack.LocalPreviewEnabled {
-			linkToStack := authenticated.Client.URL("/stack/%s", stack.ID)
+			linkToStack := authenticated.Client().URL("/stack/%s", stack.ID)
 			return mcp.NewToolResultText(fmt.Sprintf("Local preview has not been enabled for this stack, please enable local preview in the stack settings: %s", linkToStack)), nil
 		}
 
@@ -652,7 +663,7 @@ func registerLocalPreviewTool(s *server.MCPServer, options McpOptions) {
 		output := outputBuilder.String()
 
 		// Add run URL to the output
-		linkToRun := authenticated.Client.URL(
+		linkToRun := authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			runID,
@@ -710,7 +721,7 @@ func listResourcesForOneStack(ctx context.Context, id string) (*mcp.CallToolResu
 	}
 
 	variables := map[string]any{"id": graphql.ID(id)}
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return nil, fmt.Errorf("failed to query stack resources: %w", err)
 	}
 
@@ -732,7 +743,7 @@ func listResourcesForAllStacks(ctx context.Context) (*mcp.CallToolResult, error)
 		Stacks []stackWithResources `graphql:"stacks" json:"stacks,omitempty"`
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, map[string]any{}); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, map[string]any{}); err != nil {
 		return nil, fmt.Errorf("failed to query all stacks resources: %w", err)
 	}
 

--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -20,7 +20,7 @@ import (
 
 func openCommandInBrowser(ctx context.Context, cliCmd *cli.Command) error {
 	if stackID := cliCmd.String(flagStackID.Name); stackID != "" {
-		return browser.OpenURL(authenticated.Client.URL(
+		return browser.OpenURL(authenticated.Client().URL(
 			"/stack/%s",
 			stackID,
 		))
@@ -67,7 +67,7 @@ func findAndOpenStackInBrowser(ctx context.Context, p *stackSearchParams) error 
 		return errors.New("No stacks using the provided search parameters, maybe it's in a different subdir?")
 	}
 
-	return browser.OpenURL(authenticated.Client.URL(
+	return browser.OpenURL(authenticated.Client().URL(
 		"/stack/%s",
 		got.ID,
 	))
@@ -178,7 +178,7 @@ func searchStacks[T hasIDAndName](ctx context.Context, input structs.SearchInput
 		} `graphql:"searchStacks(input: $input)"`
 	}
 
-	if err := authenticated.Client.Query(
+	if err := authenticated.Client().Query(
 		ctx,
 		&query,
 		map[string]interface{}{"input": input},

--- a/internal/cmd/stack/outputs.go
+++ b/internal/cmd/stack/outputs.go
@@ -47,7 +47,7 @@ func (c *showOutputsStackCommand) showOutputs(ctx context.Context, cliCmd *cli.C
 		"stackId": graphql.ID(stackID),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return errors.Wrapf(err, "failed to query for stack ID %q", stackID)
 	}
 

--- a/internal/cmd/stack/resources.go
+++ b/internal/cmd/stack/resources.go
@@ -30,7 +30,7 @@ func resourcesListOneStack(ctx context.Context, id string) error {
 	}
 
 	variables := map[string]any{"id": graphql.ID(id)}
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return errors.Wrap(err, "failed to query one stack")
 	}
 
@@ -42,7 +42,7 @@ func resourcesListAllStacks(ctx context.Context) error {
 		Stacks []stackWithResources `graphql:"stacks" json:"stacks,omitempty"`
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{}); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, map[string]interface{}{}); err != nil {
 		return errors.Wrap(err, "failed to query list of stacks")
 	}
 

--- a/internal/cmd/stack/run_cancel.go
+++ b/internal/cmd/stack/run_cancel.go
@@ -29,13 +29,13 @@ func runCancel() cli.ActionFunc {
 			"run":   graphql.ID(cliCmd.String(flagRequiredRun.Name)),
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return err
 		}
 
 		fmt.Println("You have successfully canceled the run")
 
-		fmt.Println("The run can be visited at", authenticated.Client.URL(
+		fmt.Println("The run can be visited at", authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunDiscard.ID,

--- a/internal/cmd/stack/run_changes.go
+++ b/internal/cmd/stack/run_changes.go
@@ -39,7 +39,7 @@ func getRunChanges(ctx context.Context, stackID, runID string) ([]runChangesData
 		"stack": graphql.ID(stackID),
 		"run":   graphql.ID(runID),
 	}
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return nil, errors.Wrap(err, "failed to query one stack")
 	}
 

--- a/internal/cmd/stack/run_confirm.go
+++ b/internal/cmd/stack/run_confirm.go
@@ -35,13 +35,13 @@ func runConfirm() cli.ActionFunc {
 			requestOpts = append(requestOpts, graphql.WithHeader(internal.UserProvidedRunMetadataHeader, cliCmd.String(flagRunMetadata.Name)))
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
 			return err
 		}
 
 		fmt.Println("You have successfully confirmed a deployment")
 
-		fmt.Println("The live run can be visited at", authenticated.Client.URL(
+		fmt.Println("The live run can be visited at", authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunConfirm.ID,

--- a/internal/cmd/stack/run_deprioritize.go
+++ b/internal/cmd/stack/run_deprioritize.go
@@ -23,7 +23,7 @@ func runDeprioritize(ctx context.Context, cliCmd *cli.Command) error {
 	}
 
 	fmt.Printf("Run ID %q has been successfully deprioritized\n", runID)
-	fmt.Println("The live run can be visited at", authenticated.Client.URL(
+	fmt.Println("The live run can be visited at", authenticated.Client().URL(
 		"/stack/%s/run/%s",
 		stackID,
 		mutation.SetRunPriority.ID,

--- a/internal/cmd/stack/run_discard.go
+++ b/internal/cmd/stack/run_discard.go
@@ -29,13 +29,13 @@ func runDiscard() cli.ActionFunc {
 			"run":   graphql.ID(cliCmd.String(flagRequiredRun.Name)),
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return err
 		}
 
 		fmt.Println("You have successfully discarded a deployment")
 
-		fmt.Println("The run can be visited at", authenticated.Client.URL(
+		fmt.Println("The run can be visited at", authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunDiscard.ID,

--- a/internal/cmd/stack/run_list.go
+++ b/internal/cmd/stack/run_list.go
@@ -92,7 +92,7 @@ func queryTrackedRuns[T any](ctx context.Context, stackID string, before *string
 		} `graphql:"stack(id: $stackId)"`
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
 		return nil, errors.Wrap(err, "failed to query run list")
 	}
 
@@ -110,7 +110,7 @@ func queryPreviewRuns[T any](ctx context.Context, stackID string, before *string
 		} `graphql:"stack(id: $stackId)"`
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
 		return nil, errors.Wrap(err, "failed to query run list")
 	}
 

--- a/internal/cmd/stack/run_logs.go
+++ b/internal/cmd/stack/run_logs.go
@@ -43,7 +43,7 @@ func runLogs(ctx context.Context, cliCmd *cli.Command) error {
 		}
 
 		var before *string
-		if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, map[string]interface{}{"stackId": stackID, "before": before}); err != nil {
 			return errors.Wrap(err, "failed to query run list")
 		}
 

--- a/internal/cmd/stack/run_prioritize.go
+++ b/internal/cmd/stack/run_prioritize.go
@@ -24,7 +24,7 @@ func runPrioritize(ctx context.Context, cliCmd *cli.Command) error {
 	}
 
 	fmt.Printf("Run ID %q has been successfully prioritized\n", runID)
-	fmt.Println("The live run can be visited at", authenticated.Client.URL(
+	fmt.Println("The live run can be visited at", authenticated.Client().URL(
 		"/stack/%s/run/%s",
 		stackID,
 		mutation.SetRunPriority.ID,
@@ -57,7 +57,7 @@ func setRunPriority(ctx context.Context, stackID, runID string, prioritize bool)
 		"prioritize": graphql.Boolean(prioritize),
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return setRunPriorityMutation{}, err
 	}
 

--- a/internal/cmd/stack/run_replan.go
+++ b/internal/cmd/stack/run_replan.go
@@ -55,12 +55,12 @@ func runReplan(ctx context.Context, cliCmd *cli.Command) error {
 		"targets": targets,
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 
 	fmt.Printf("Run ID %q is being replanned\n", runID)
-	fmt.Println("The live run can be visited at", authenticated.Client.URL(
+	fmt.Println("The live run can be visited at", authenticated.Client().URL(
 		"/stack/%s/run/%s",
 		stackID,
 		mutation.RunTargetedReplan.ID,

--- a/internal/cmd/stack/run_retry.go
+++ b/internal/cmd/stack/run_retry.go
@@ -29,12 +29,12 @@ func runRetry(ctx context.Context, cliCmd *cli.Command) error {
 		"run":   graphql.ID(runID),
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 
 	fmt.Printf("Run ID %q has been successfully retried\n", runID)
-	fmt.Println("The live run can be visited at", authenticated.Client.URL(
+	fmt.Println("The live run can be visited at", authenticated.Client().URL(
 		"/stack/%s/run/%s",
 		stackID,
 		mutation.RunRetry.ID,

--- a/internal/cmd/stack/run_review.go
+++ b/internal/cmd/stack/run_review.go
@@ -67,5 +67,5 @@ func addRunReview(ctx context.Context, stackID, runID, note string, decision enu
 		"note":     graphql.String(note),
 	}
 
-	return authenticated.Client.Mutate(ctx, &mutation, variables)
+	return authenticated.Client().Mutate(ctx, &mutation, variables)
 }

--- a/internal/cmd/stack/run_stop.go
+++ b/internal/cmd/stack/run_stop.go
@@ -30,13 +30,13 @@ func runStop() cli.ActionFunc {
 			"note":  graphql.String("Stopped by spacectl"),
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 			return err
 		}
 
 		fmt.Println("You have successfully attempted to stop the run")
 
-		fmt.Println("The run can be visited at", authenticated.Client.URL(
+		fmt.Println("The run can be visited at", authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunStop.ID,

--- a/internal/cmd/stack/run_trigger.go
+++ b/internal/cmd/stack/run_trigger.go
@@ -63,13 +63,13 @@ func runTrigger(spaceliftType, humanType string) cli.ActionFunc {
 			requestOpts = append(requestOpts, graphql.WithHeader(internal.UserProvidedRunMetadataHeader, cliCmd.String(flagRunMetadata.Name)))
 		}
 
-		if err := authenticated.Client.Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
 			return err
 		}
 
 		fmt.Println("You have successfully created a", humanType)
 
-		fmt.Println("The live run can be visited at", authenticated.Client.URL(
+		fmt.Println("The live run can be visited at", authenticated.Client().URL(
 			"/stack/%s/run/%s",
 			stackID,
 			mutation.RunTrigger.ID,
@@ -99,7 +99,7 @@ func runTrigger(spaceliftType, humanType string) cli.ActionFunc {
 				"run":   graphql.ID(runID),
 			}
 
-			if err := authenticated.Client.Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
+			if err := authenticated.Client().Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
 				return err
 			}
 

--- a/internal/cmd/stack/set_current_commit.go
+++ b/internal/cmd/stack/set_current_commit.go
@@ -31,7 +31,7 @@ func setCurrentCommit(ctx context.Context, cliCmd *cli.Command) error {
 		"stack": graphql.ID(stackID),
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 

--- a/internal/cmd/stack/show.go
+++ b/internal/cmd/stack/show.go
@@ -133,7 +133,7 @@ func (c *showStackCommand) showStack(ctx context.Context, cliCmd *cli.Command) e
 		"stackId": graphql.ID(stackID),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return errors.Wrapf(err, "failed to query for stack ID %q", stackID)
 	}
 

--- a/internal/cmd/stack/stack_selector.go
+++ b/internal/cmd/stack/stack_selector.go
@@ -99,7 +99,7 @@ func stackGetByID[T hasIDAndName](ctx context.Context, stackID string) (*T, erro
 		"id": graphql.ID(stackID),
 	}
 
-	err := authenticated.Client.Query(ctx, &query, variables)
+	err := authenticated.Client().Query(ctx, &query, variables)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query GraphQL API when checking if a stack exists: %w", err)
 	}
@@ -120,7 +120,7 @@ func stackGetByRunID[T hasIDAndName](ctx context.Context, runID string) (*T, err
 		"runId": graphql.ID(runID),
 	}
 
-	err := authenticated.Client.Query(ctx, &query, variables)
+	err := authenticated.Client().Query(ctx, &query, variables)
 	if err != nil {
 		if err.Error() == "not found" {
 			return nil, errNoStackFound

--- a/internal/cmd/stack/sync.go
+++ b/internal/cmd/stack/sync.go
@@ -29,5 +29,5 @@ func syncCommit(ctx context.Context, cliCmd *cli.Command) error {
 		"stack": graphql.ID(stackID),
 	}
 
-	return authenticated.Client.Mutate(ctx, &mutation, variables)
+	return authenticated.Client().Mutate(ctx, &mutation, variables)
 }

--- a/internal/cmd/stack/task_command.go
+++ b/internal/cmd/stack/task_command.go
@@ -36,13 +36,13 @@ func taskCommand(ctx context.Context, cliCmd *cli.Command) error {
 		requestOpts = append(requestOpts, graphql.WithHeader(internal.UserProvidedRunMetadataHeader, cliCmd.String(flagRunMetadata.Name)))
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables, requestOpts...); err != nil {
 		return err
 	}
 
 	fmt.Println("You have successfully started a task")
 
-	fmt.Println("The live task can be visited at", authenticated.Client.URL(
+	fmt.Println("The live task can be visited at", authenticated.Client().URL(
 		"/stack/%s/run/%s",
 		stackID,
 		mutation.TaskCreate.ID,

--- a/internal/cmd/workerpools/pool.go
+++ b/internal/cmd/workerpools/pool.go
@@ -47,7 +47,7 @@ func (c *listPoolsCommand) listPools(ctx context.Context, cliCmd *cli.Command) e
 
 	var query listPoolsQuery
 
-	if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{}); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, map[string]interface{}{}); err != nil {
 		return err
 	}
 

--- a/internal/cmd/workerpools/watch.go
+++ b/internal/cmd/workerpools/watch.go
@@ -34,7 +34,7 @@ func watch(ctx context.Context, _ *cli.Command) error {
 // If public worker pool is selected and empty string is returned.
 func findAndSelectWorkerPool(ctx context.Context) (string, error) {
 	var query listPoolsQuery
-	if err := authenticated.Client.Query(ctx, &query, map[string]interface{}{}); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, map[string]interface{}{}); err != nil {
 		return "", err
 	}
 

--- a/internal/cmd/workerpools/worker.go
+++ b/internal/cmd/workerpools/worker.go
@@ -63,7 +63,7 @@ func (c *listWorkersCommand) listWorkers(ctx context.Context, cliCmd *cli.Comman
 		"workerPool": workerPoolID,
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return err
 	}
 
@@ -126,7 +126,7 @@ func (c *drainWorkerCommand) drainWorker(ctx context.Context, cliCmd *cli.Comman
 		"drain":      graphql.Boolean(true),
 	}
 
-	if err := authenticated.Client.Mutate(ctx, &mutation, variables); err != nil {
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
 		return err
 	}
 
@@ -180,7 +180,7 @@ func (c *drainWorkerCommand) drainedWorkerIsIdle(ctx context.Context, workerID s
 		"workerPool": graphql.ID(workerPoolID),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return false, err
 	}
 
@@ -215,7 +215,7 @@ func (c *undrainWorkerCommand) undrainWorker(ctx context.Context, cliCmd *cli.Co
 		"drain":      graphql.Boolean(false),
 	}
 
-	err := authenticated.Client.Mutate(ctx, &mutation, variables)
+	err := authenticated.Client().Mutate(ctx, &mutation, variables)
 
 	if err != nil {
 		return err
@@ -232,7 +232,7 @@ func (c *cycleWorkersCommand) cycleWorkers(ctx context.Context, cliCmd *cli.Comm
 		"workerPoolId": graphql.ID(cliCmd.String(flagPoolIDNamed.Name)),
 	}
 
-	err := authenticated.Client.Mutate(ctx, &mutation, variables)
+	err := authenticated.Client().Mutate(ctx, &mutation, variables)
 
 	if err != nil {
 		return err

--- a/internal/logs/explorer.go
+++ b/internal/logs/explorer.go
@@ -103,7 +103,7 @@ func (e *Explorer) getHistory(ctx context.Context) ([]structs.RunStateTransition
 		"run":   graphql.ID(e.run),
 	}
 
-	if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return nil, err
 	}
 

--- a/internal/logs/query.go
+++ b/internal/logs/query.go
@@ -40,7 +40,7 @@ func runStateLogs(ctx context.Context, stack, run string, state structs.RunState
 	var backOff time.Duration
 
 	for {
-		if err := authenticated.Client.Query(ctx, &query, variables); err != nil {
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Description

```
{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"Showing 5 policies:\n[{\"id\":\"app\",\"name\":\"a....
....
** I delete my session**
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"failed to search policies: failed search for policies: unauthorized: You can re-login using `spacectl profile login`"}}
**I login again**
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_policies","arguments":{"limit":5}}}
{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"Showing 5 policies:\n[{\"id\":\"app\",\"name\":\"a....
```
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

We will now reload the client before making a request using the MCP. Before it would build the client once and never reload it. It will now work exactly the same as other commands do.

It is a bit unfortunate that we have to introduce a mutex on a global variable and it would make sense to remove it entirely but that is some thing for the future. This affects all command and al queries/mutations.

The only relevant change really is the file in **internal/cmd/authenticated/client.go**

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

