### PR TITLE
Only show stacks with local preview enabled

### DIFF
--- a/internal/cmd/stack/delete.go
+++ b/internal/cmd/stack/delete.go
@@ -27,7 +27,7 @@ var flagSkipConfirmation = &cli.BoolFlag{
 
 func deleteStack() cli.ActionFunc {
 	return func(ctx context.Context, cliCmd *cli.Command) error {
-		stackID, err := getStackID(ctx, cliCmd)
+		stackID, err := getStackID(ctx, cliCmd, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/dependencies.go
+++ b/internal/cmd/stack/dependencies.go
@@ -55,7 +55,7 @@ func dependenciesOff(ctx context.Context, cliCmd *cli.Command) error {
 }
 
 func dependenciesListOneStack(ctx context.Context, cliCmd *cli.Command) (*stackWithDependencies, error) {
-	id, err := getStackID(ctx, cliCmd)
+	id, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/stack/enable.go
+++ b/internal/cmd/stack/enable.go
@@ -34,7 +34,7 @@ func disable(ctx context.Context, cliCmd *cli.Command) error {
 }
 
 func enableDisable[T any](ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/environment.go
+++ b/internal/cmd/stack/environment.go
@@ -90,7 +90,7 @@ func setVar(ctx context.Context, cliCmd *cli.Command) error {
 	envName := cliCmd.Args().Get(0)
 	envValue := cliCmd.Args().Get(1)
 
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (e *listEnvCommand) listEnv(ctx context.Context, cliCmd *cli.Command) error
 		return err
 	}
 
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func mountFile(ctx context.Context, cliCmd *cli.Command) error {
 	nArgs := cliCmd.NArg()
 
 	envName := cliCmd.Args().Get(0)
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}
@@ -338,7 +338,7 @@ func mountFile(ctx context.Context, cliCmd *cli.Command) error {
 }
 
 func deleteEnvironment(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -26,14 +26,19 @@ func localPreview(useHeaders bool) cli.ActionFunc {
 			return err
 		}
 
-		stack, err := getStack[stack](ctx, cliCmd)
-		if err != nil {
-			return err
+		// Only find stacks where local preview is enabled
+		extraConditions := []structs.QueryPredicate{
+			{
+				Field: "localPreviewEnabled",
+				Constraint: structs.QueryFieldConstraint{
+					BooleanEquals: &[]graphql.Boolean{true},
+				},
+			},
 		}
 
-		if !stack.LocalPreviewEnabled {
-			linkToStack := authenticated.Client().URL("/stack/%s", stack.ID)
-			return fmt.Errorf("local preview has not been enabled for this stack, please enable local preview in the stack settings: %s", linkToStack)
+		stack, err := getStack[stack](ctx, cliCmd, extraConditions)
+		if err != nil {
+			return err
 		}
 
 		var packagePath *string

--- a/internal/cmd/stack/lock.go
+++ b/internal/cmd/stack/lock.go
@@ -28,7 +28,7 @@ var flagStackLockNote = &cli.StringFlag{
 }
 
 func lock(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func lock(ctx context.Context, cliCmd *cli.Command) error {
 }
 
 func unlock(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -62,7 +62,7 @@ func openCommandInBrowser(ctx context.Context, cliCmd *cli.Command) error {
 }
 
 func findAndOpenStackInBrowser(ctx context.Context, p *stackSearchParams) error {
-	got, err := findAndSelectStack[stack](ctx, p, false)
+	got, err := findAndSelectStack[stack](ctx, p, false, nil)
 	if errors.Is(err, errNoStackFound) {
 		return errors.New("No stacks using the provided search parameters, maybe it's in a different subdir?")
 	}

--- a/internal/cmd/stack/outputs.go
+++ b/internal/cmd/stack/outputs.go
@@ -31,7 +31,7 @@ type showOutputsQuery struct {
 type showOutputsStackCommand struct{}
 
 func (c *showOutputsStackCommand) showOutputs(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/resources.go
+++ b/internal/cmd/stack/resources.go
@@ -12,7 +12,7 @@ import (
 )
 
 func resourcesList(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		if !errors.Is(err, errNoStackFound) {
 			return err

--- a/internal/cmd/stack/run_cancel.go
+++ b/internal/cmd/stack/run_cancel.go
@@ -13,7 +13,7 @@ import (
 
 func runCancel() cli.ActionFunc {
 	return func(ctx context.Context, cliCmd *cli.Command) error {
-		stackID, err := getStackID(ctx, cliCmd)
+		stackID, err := getStackID(ctx, cliCmd, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_changes.go
+++ b/internal/cmd/stack/run_changes.go
@@ -12,7 +12,7 @@ import (
 )
 
 func runChanges(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_confirm.go
+++ b/internal/cmd/stack/run_confirm.go
@@ -14,7 +14,7 @@ import (
 
 func runConfirm() cli.ActionFunc {
 	return func(ctx context.Context, cliCmd *cli.Command) error {
-		stackID, err := getStackID(ctx, cliCmd)
+		stackID, err := getStackID(ctx, cliCmd, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_deprioritize.go
+++ b/internal/cmd/stack/run_deprioritize.go
@@ -11,7 +11,7 @@ import (
 )
 
 func runDeprioritize(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_discard.go
+++ b/internal/cmd/stack/run_discard.go
@@ -13,7 +13,7 @@ import (
 
 func runDiscard() cli.ActionFunc {
 	return func(ctx context.Context, cliCmd *cli.Command) error {
-		stackID, err := getStackID(ctx, cliCmd)
+		stackID, err := getStackID(ctx, cliCmd, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_list.go
+++ b/internal/cmd/stack/run_list.go
@@ -20,7 +20,7 @@ func runList(ctx context.Context, cliCmd *cli.Command) error {
 		return err
 	}
 
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_logs.go
+++ b/internal/cmd/stack/run_logs.go
@@ -20,7 +20,7 @@ import (
 type actionOnRunState func(state structs.RunState, stackID, runID string) error
 
 func runLogs(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_prioritize.go
+++ b/internal/cmd/stack/run_prioritize.go
@@ -12,7 +12,7 @@ import (
 )
 
 func runPrioritize(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_replan.go
+++ b/internal/cmd/stack/run_replan.go
@@ -16,7 +16,7 @@ import (
 const rocketEmoji = "\U0001F680"
 
 func runReplan(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_retry.go
+++ b/internal/cmd/stack/run_retry.go
@@ -12,7 +12,7 @@ import (
 )
 
 func runRetry(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_review.go
+++ b/internal/cmd/stack/run_review.go
@@ -24,7 +24,7 @@ var flagRunReviewNote = &cli.StringFlag{
 }
 
 func runApprove(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func runApprove(ctx context.Context, cliCmd *cli.Command) error {
 }
 
 func runReject(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_stop.go
+++ b/internal/cmd/stack/run_stop.go
@@ -13,7 +13,7 @@ import (
 
 func runStop() cli.ActionFunc {
 	return func(ctx context.Context, cliCmd *cli.Command) error {
-		stackID, err := getStackID(ctx, cliCmd)
+		stackID, err := getStackID(ctx, cliCmd, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_trigger.go
+++ b/internal/cmd/stack/run_trigger.go
@@ -16,7 +16,7 @@ import (
 
 func runTrigger(spaceliftType, humanType string) cli.ActionFunc {
 	return func(ctx context.Context, cliCmd *cli.Command) error {
-		stackID, err := getStackID(ctx, cliCmd)
+		stackID, err := getStackID(ctx, cliCmd, nil)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/set_current_commit.go
+++ b/internal/cmd/stack/set_current_commit.go
@@ -12,7 +12,7 @@ import (
 )
 
 func setCurrentCommit(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/show.go
+++ b/internal/cmd/stack/show.go
@@ -118,7 +118,7 @@ type showStackQuery struct {
 type showStackCommand struct{}
 
 func (c *showStackCommand) showStack(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/sync.go
+++ b/internal/cmd/stack/sync.go
@@ -11,7 +11,7 @@ import (
 )
 
 func syncCommit(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/task_command.go
+++ b/internal/cmd/stack/task_command.go
@@ -14,7 +14,7 @@ import (
 )
 
 func taskCommand(ctx context.Context, cliCmd *cli.Command) error {
-	stackID, err := getStackID(ctx, cliCmd)
+	stackID, err := getStackID(ctx, cliCmd, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Attempt at an implementation for https://github.com/spacelift-io/spacectl/issues/362

This doesn't work currently as the `localPreviewEnabled` field doesn't seem to be valid for searching stacks:
```
2025/12/19 11:56:36 failed search for stacks: could not parse search query: couldn't parse 2nd predicate: unknown field: localPreviewEnabled
```

Submitting this in case it's a simple change that can be made (wrong field name or similar), but I couldn't find docs on the list of accepted predicates when searching stacks.

I'm also not a massive fan of the additional argument to `getStack` but couldn't see an easy way to avoid it. I've made it accept a slice of predicates to try and be as generic as possible in case there are other places where we'd want to pre-filter the stacks when showing the selector

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- Adds new `extraConditions` argument to `getStack`, which accepts a slice of `QueryPredicate` which are then appended to the graphql call made when searching for stacks.
- When running local-preview adds a predicate that (attempts to!) filters for stacks with local preview enabled

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [x] All existing tests pass

## Screenshots (if applicable)

Add screenshots to show visual changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings

## Related Issues

Closes #(issue number)
Fixes #(issue number)
Related to #(issue number)
