### PR TITLE
Return error instead of empty list when listing modules with expired token (#364)

### DIFF
--- a/internal/cmd/module/list.go
+++ b/internal/cmd/module/list.go
@@ -220,6 +220,13 @@ func searchModules(ctx context.Context, input structs.SearchInput) (searchModule
 		return searchModulesResult{}, errors.Wrap(err, "failed search for modules")
 	}
 
+	if len(query.SearchModulesOutput.Edges) == 0 {
+		_, err := authenticated.CurrentViewer(ctx)
+		if errors.Is(err, authenticated.ErrViewerUnknown) {
+			return searchModulesResult{}, errors.New("You are not logged in, could not find modules")
+		}
+	}
+
 	nodes := make([]module, 0)
 	for _, q := range query.SearchModulesOutput.Edges {
 		nodes = append(nodes, q.Node)

--- a/internal/cmd/module/mcp.go
+++ b/internal/cmd/module/mcp.go
@@ -604,6 +604,13 @@ func searchModulesMCP(ctx context.Context, input structs.SearchInput) (*mcpSearc
 		return nil, errors.Wrap(err, "failed to execute modules search query")
 	}
 
+	if len(query.SearchModulesOutput.Edges) == 0 {
+		_, err := authenticated.CurrentViewer(ctx)
+		if errors.Is(err, authenticated.ErrViewerUnknown) {
+			return nil, errors.New("You are not logged in, could not find modules")
+		}
+	}
+
 	nodes := make([]module, 0)
 	for _, q := range query.SearchModulesOutput.Edges {
 		nodes = append(nodes, q.Node)


### PR DESCRIPTION
## Description

Replicates the way the check is performed when listing stacks.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- Adds check for unknown viewer like what stack list code has to module list function
- Same for MCP module list function

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed (no tests existed for this or any related functionality)
- [x] All existing tests pass

## Screenshots (if applicable)

Add screenshots to show visual changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Related Issues

Fixes #364
