### PR TITLE
Fix panic on close

### DIFF
--- a/internal/cmd/stack/open_command.go
+++ b/internal/cmd/stack/open_command.go
@@ -66,6 +66,9 @@ func findAndOpenStackInBrowser(ctx context.Context, p *stackSearchParams) error 
 	if errors.Is(err, errNoStackFound) {
 		return errors.New("No stacks using the provided search parameters, maybe it's in a different subdir?")
 	}
+	if err != nil {
+		return err
+	}
 
 	return browser.OpenURL(authenticated.Client().URL(
 		"/stack/%s",


### PR DESCRIPTION
## Description

```
spacectl stack open
Search results exceeded maximum capacity (30) some stacks might be missing
  ▸ stack-no-preview-34
    stack-no-preview-18
    stack-with-preview-1
    stack-with-preview-8
    stack-no-preview-37
    stack-no-preview-19
    stack-no-preview-42
    stack-no-preview-53
    stack-no-preview-59
↓   stack-no-preview-20
2026/01/05 15:36:48 ^C
```

## Type of Change

- [x] Bug fix


Closes https://github.com/spacelift-io/spacectl/issues/369
