### PR TITLE
Logs and states should go in the sync when printing logs

### DIFF
--- a/internal/logs/explorer.go
+++ b/internal/logs/explorer.go
@@ -133,7 +133,7 @@ func (e *Explorer) processHistory(ctx context.Context, sink chan<- string, histo
 			return nil, false, err
 		}
 
-		e.print(&transition)
+		e.print(&transition, sink)
 
 		terminal, err := e.processTransition(ctx, &transition, sink)
 		if err != nil {
@@ -183,12 +183,12 @@ func (e *Explorer) processTransition(ctx context.Context, transition *structs.Ru
 	return transition.Terminal, nil
 }
 
-func (e *Explorer) print(transition *structs.RunStateTransition) {
+func (e *Explorer) print(transition *structs.RunStateTransition, sink chan<- string) {
 	if e.targetPhase != nil {
 		return
 	}
 
-	fmt.Printf(`
+	sink <- fmt.Sprintf(`
 -----------------
 %s
 -----------------


### PR DESCRIPTION
## Description

I was not actually able to reproduce the log issue mentioned, but after exploring the code, this seems like it might be a the bug causing this?

We would print the states to the terminal, but send logs to the sink. Now we both send this and logs to the sink. Seems to work alright now. I suspect that if this was the case, this would be a hard to reproduce race condition anyway. Even the bug report states that this doesn't happen all the time.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


