### PR TITLE
chore(ci): add artifacts message as footer, not header

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,7 +85,7 @@ release:
   draft: false
   extra_files:
     - glob: ./key.*
-  header: |
+  footer: |
     ## Artifacts
     ### Binaries
     


### PR DESCRIPTION
## Description

Currently the information about artifacts is the header of the release. This moves any interesting information (the actual changes) out of view in the main GitHub overview. By changing it to be part of the footer, it'll be easier for users to track what changed in the repository while retaining the information about the artifacts. 

## Type of Change

- [X] Documentation update

## Changes Made

- Changed artifacts message from header to footer

## Testing

N/A

## Screenshots (if applicable)

Current situation:

<img width="927" height="575" alt="Screenshot 2026-01-13 at 10 16 01" src="https://github.com/user-attachments/assets/d9d61066-d4f6-4777-b13d-5fa1b70f8a2c" />

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] My changes generate no new warnings
