### PR TITLE
feat: add stack promote command to promote proposed runs to tracked runs

### DIFF
--- a/internal/cmd/stack/run_promote.go
+++ b/internal/cmd/stack/run_promote.go
@@ -1,0 +1,55 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v3"
+
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+	"github.com/spacelift-io/spacectl/internal/logs"
+)
+
+func runPromote() cli.ActionFunc {
+	return func(ctx context.Context, cliCmd *cli.Command) error {
+		stackID, err := getStackID(ctx, cliCmd)
+		if err != nil {
+			return err
+		}
+
+		var mutation struct {
+			RunPromote struct {
+				ID string `graphql:"id"`
+			} `graphql:"runPromote(stack: $stack, run: $run)"`
+		}
+
+		variables := map[string]any{
+			"stack": graphql.ID(stackID),
+			"run":   graphql.ID(cliCmd.String(flagRequiredRun.Name)),
+		}
+
+		if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
+			return err
+		}
+
+		fmt.Println("You have successfully promoted the run to a tracked run")
+
+		fmt.Println("The live run can be visited at", authenticated.Client().URL(
+			"/stack/%s/run/%s",
+			stackID,
+			mutation.RunPromote.ID,
+		))
+
+		if !cliCmd.Bool(flagTail.Name) {
+			return nil
+		}
+
+		terminal, err := logs.NewExplorer(stackID, mutation.RunPromote.ID).RunFilteredLogs(ctx)
+		if err != nil {
+			return err
+		}
+
+		return terminal.Error()
+	}
+}

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -344,6 +344,26 @@ func Command() cmd.Command {
 			},
 			{
 				Category: "Run management",
+				Name:     "promote",
+				Usage:    "Promote a proposed run to a tracked run",
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagStackID,
+								flagRequiredRun,
+								flagTail,
+							},
+							Action:    runPromote(),
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+				},
+			},
+			{
+				Category: "Run management",
 				Name:     "prioritize",
 				Usage:    "Prioritize a run",
 				Versions: []cmd.VersionedCommand{


### PR DESCRIPTION
Adds a new spacectl stack promote command that promotes a proposed (preview) run to a tracked (deployment) run using the runPromote GraphQL mutation.            
                                                                                                                                                                   
  Type of Change                                                                                                                                                   
                                                                                                                                                                   
                                                                                                                                    
  - New feature                                                                                                                                                    
                                                                                                                          
                                                                                                                                                                   
  Changes Made                                                                                                                                                     
                                                                                                                                                                   
  - Added run_promote.go implementing the runPromote GraphQL mutation                                                                                              
  - Registered the promote subcommand under stack in stack.go                                                                                                      
  - Supports --id, --run (required), and --tail flags                                                                                                              
  - Follows existing patterns from run_confirm.go and similar commands                                                                                             
                                                                                                                                                                   
  Testing                                                                                                                                                          
                                                                                                                                                                   
  - I have tested these changes locally                                                                                                                            
                                                                                                               
                                                                                                                                                                   
  Checklist                                                                                                                                                        
                                                                                                                                                                   
  - My code follows the project's style guidelines                                                                                                                 
  - I have performed a self-review of my code                                                                                                                      
  - I have commented my code where necessary                                                                                                                       
  - My changes generate no new warnings 
  
## Related Issues

Closes # https://github.com/spacelift-io/spacectl/issues/374
 
 
