### PR TITLE
fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           app-id: ${{ secrets.WINGET_APP_ID }}
           private-key: ${{ secrets.WINGET_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            winget-pkgs
 
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

The actions/create-github-app-token@v2 action by default creates a token scoped only to the current repository.
To access the spacelift-io/winget-pkgs repository, we need to explicitly specify the repositories parameter.

Fixes #360

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- List the main changes
- Include any important details
- Mention files or components affected

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Screenshots (if applicable)

Add screenshots to show visual changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings

## Related Issues

Closes #(issue number)
Fixes #(issue number)
Related to #(issue number)
