### PR TITLE
Fix MCP local preview panic

### DIFF
--- a/internal/cmd/stack/mcp.go
+++ b/internal/cmd/stack/mcp.go
@@ -614,9 +614,12 @@ func registerLocalPreviewTool(s *server.MCPServer, options McpOptions) {
 			return mcp.NewToolResultText(fmt.Sprintf("Local preview has not been enabled for this stack, please enable local preview in the stack settings: %s", linkToStack)), nil
 		}
 
-		var envVars []EnvironmentVariable
+		envVars := make([]EnvironmentVariable, 0)
 		if envVarParams := request.GetArguments()["environment_variables"]; envVarParams != nil {
-			v := envVarParams.(map[string]any)
+			v, ok := envVarParams.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("environment_variables must be an object/map, got %T", envVarParams)
+			}
 			for k, v := range v {
 				if o, ok := v.(string); ok {
 					envVars = append(envVars, EnvironmentVariable{


### PR DESCRIPTION
## Description

Fixes a panic when a wrong value type is passed.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

