### PR TITLE
Fix goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean --snapshot=${{ !startsWith(github.ref, 'refs/tags/v') }}
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,47 +24,22 @@ archives:
       - README.md
       - completions/*
 
-dockers:
-  - use: buildx
-    goarch: amd64
-    build_flag_templates:
-     - "--platform=linux/amd64"
-     - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-     - "--label=org.opencontainers.image.vendor=Spacelift"
-     - "--label=org.opencontainers.image.description=Spacelift CLI version {{ .Version }}"
-     - "--label=org.opencontainers.image.url=https://github.com/spacelift-io/spacectl"
-     - "--label=org.opencontainers.image.documentation=https://github.com/spacelift-io/spacectl/blob/main/README.md"
-     - "--label=org.opencontainers.image.source=https://github.com/spacelift-io/spacectl"
-     - "--label=org.opencontainers.image.version={{ .Version }}"
-     - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-     - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
-    image_templates: ["ghcr.io/spacelift-io/spacectl:{{ .Version }}-amd64"]
-
-  - use: buildx
-    goarch: arm64
-    build_flag_templates:
-     - "--platform=linux/arm64"
-     - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-     - "--label=org.opencontainers.image.vendor=Spacelift"
-     - "--label=org.opencontainers.image.description=Spacelift CLI version {{ .Version }}"
-     - "--label=org.opencontainers.image.url=https://github.com/spacelift-io/spacectl"
-     - "--label=org.opencontainers.image.documentation=https://github.com/spacelift-io/spacectl/blob/main/README.md"
-     - "--label=org.opencontainers.image.source=https://github.com/spacelift-io/spacectl"
-     - "--label=org.opencontainers.image.version={{ .Version }}"
-     - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-     - "--label=org.opencontainers.image.created={{ time \"2006-01-02T15:04:05Z07:00\" }}"
-    image_templates: ["ghcr.io/spacelift-io/spacectl:{{ .Version }}-arm64"]
-
-docker_manifests:
-  - name_template: ghcr.io/spacelift-io/spacectl:{{ .Version }}
-    image_templates:
-    - ghcr.io/spacelift-io/spacectl:{{ .Version }}-amd64
-    - ghcr.io/spacelift-io/spacectl:{{ .Version }}-arm64
-
-  - name_template: ghcr.io/spacelift-io/spacectl:latest
-    image_templates:
-    - ghcr.io/spacelift-io/spacectl:{{ .Version }}-amd64
-    - ghcr.io/spacelift-io/spacectl:{{ .Version }}-arm64
+dockers_v2:
+  - images:
+      - "ghcr.io/spacelift-io/spacectl"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+    labels:
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.vendor": "Spacelift"
+      "org.opencontainers.image.description": "Spacelift CLI version {{ .Version }}"
+      "org.opencontainers.image.url": "https://github.com/spacelift-io/spacectl"
+      "org.opencontainers.image.documentation": "https://github.com/spacelift-io/spacectl/blob/main/README.md"
+      "org.opencontainers.image.source": "https://github.com/spacelift-io/spacectl"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.created": "{{ time \"2006-01-02T15:04:05Z07:00\" }}"
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
@@ -100,8 +75,14 @@ release:
 changelog:
   use: github-native
 
-brews:
+homebrew_casks:
   - name: "{{ .ProjectName }}"
+    binaries:
+      - "{{ .ProjectName }}"
+    completions:
+      bash: "completions/{{ .ProjectName }}.bash"
+      zsh: "completions/{{ .ProjectName }}.zsh"
+      fish: "completions/{{ .ProjectName }}.fish"
     repository:
       owner: "spacelift-io"
       name: "homebrew-spacelift"
@@ -109,10 +90,6 @@ brews:
     homepage: https://github.com/spacelift-io/spacectl
     description: "Spacelift client and CLI"
     license: "MIT"
-    extra_install: |
-      bash_completion.install "completions/{{ .ProjectName }}.bash" => "{{ .ProjectName }}"
-      zsh_completion.install "completions/{{ .ProjectName }}.zsh" => "_{{ .ProjectName }}"
-      fish_completion.install "completions/{{ .ProjectName }}.fish"
 
 winget:
   - name: "{{ .ProjectName }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine
 
+ARG TARGETPLATFORM
+
 RUN set -xe \
     && apk add --no-cache git
 
-COPY spacectl /usr/local/bin/spacectl
+COPY $TARGETPLATFORM/spacectl /usr/local/bin/spacectl
 ENTRYPOINT ["/usr/local/bin/spacectl"]


### PR DESCRIPTION
## Description

Fixing goreleaser warnings:

```
Run goreleaser/goreleaser-action@v6
Warning: You are using 'latest' as default version. Will lock to '~> v2'.
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.13.3/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/b23df5fb-a66f-46ea-8eb5-879386309e60 -f /home/runner/work/_temp/6c2b4bd4-202d-4ef1-b3e6-6ef69b99b60e
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/2.13.3/x64/goreleaser release --clean --snapshot=false
  • cleaning distribution directory
  • loading environment variables
    • using token from $GITHUB_TOKEN
  • getting and validating git state
    • git state                                      commit=5db53b403f4ed5e99d6d391ae84948e2ec9d6980 branch=HEAD current_tag=v1.18.3 previous_tag=v1.18.2 dirty=false
  • parsing tag
  • setting defaults
    • dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
    • dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
    • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
```
