### PR TITLE
fix: use caFile variable instead of hardcoded "cacert" in configureTLS

### DIFF
--- a/internal/cmd/authenticated/client.go
+++ b/internal/cmd/authenticated/client.go
@@ -80,8 +80,19 @@ func configureTLS(httpClient *http.Client) error {
 		MinVersion: tls.VersionTLS12,
 	}
 
-	if caFile, ok := os.LookupEnv(EnvSpaceliftAPIClientCA); ok && caFile != "" {
-		caCert, err := os.ReadFile("cacert")
+	// Check SPACELIFT_API_TLS_CA first, then fall back to SSL_CERT_FILE.
+	// Setting RootCAs to a non-nil pool forces Go's pure-Go certificate
+	// verifier, bypassing Security.framework (which fails in sandboxed
+	// environments where macOS Keychain is inaccessible).
+	caFile := ""
+	if f, ok := os.LookupEnv(EnvSpaceliftAPIClientCA); ok && f != "" {
+		caFile = f
+	} else if f, ok := os.LookupEnv("SSL_CERT_FILE"); ok && f != "" {
+		caFile = f
+	}
+
+	if caFile != "" {
+		caCert, err := os.ReadFile(caFile)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/authenticated/client_test.go
+++ b/internal/cmd/authenticated/client_test.go
@@ -1,0 +1,114 @@
+package authenticated
+
+import (
+	"crypto/tls"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureTLS_NoEnvVars(t *testing.T) {
+	t.Setenv(EnvSpaceliftAPIClientCA, "")
+	t.Setenv("SSL_CERT_FILE", "")
+
+	httpClient := &http.Client{}
+	err := configureTLS(httpClient)
+	require.NoError(t, err)
+
+	transport := httpClient.Transport.(*http.Transport)
+	assert.Nil(t, transport.TLSClientConfig.RootCAs, "RootCAs should be nil when no CA env vars are set")
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+}
+
+func TestConfigureTLS_SpaceliftCA(t *testing.T) {
+	caFile := writeTempCA(t)
+
+	t.Setenv(EnvSpaceliftAPIClientCA, caFile)
+	t.Setenv("SSL_CERT_FILE", "")
+
+	httpClient := &http.Client{}
+	err := configureTLS(httpClient)
+	require.NoError(t, err)
+
+	transport := httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs, "RootCAs should be set when SPACELIFT_API_TLS_CA is provided")
+}
+
+func TestConfigureTLS_SSLCertFileFallback(t *testing.T) {
+	caFile := writeTempCA(t)
+
+	t.Setenv(EnvSpaceliftAPIClientCA, "")
+	t.Setenv("SSL_CERT_FILE", caFile)
+
+	httpClient := &http.Client{}
+	err := configureTLS(httpClient)
+	require.NoError(t, err)
+
+	transport := httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs, "RootCAs should be set when SSL_CERT_FILE is provided")
+}
+
+func TestConfigureTLS_SpaceliftCATakesPrecedence(t *testing.T) {
+	caFile := writeTempCA(t)
+
+	t.Setenv(EnvSpaceliftAPIClientCA, caFile)
+	t.Setenv("SSL_CERT_FILE", "/nonexistent/path.pem")
+
+	httpClient := &http.Client{}
+	err := configureTLS(httpClient)
+	require.NoError(t, err, "should use SPACELIFT_API_TLS_CA and ignore invalid SSL_CERT_FILE")
+
+	transport := httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+}
+
+func TestConfigureTLS_InvalidCAPath(t *testing.T) {
+	t.Setenv(EnvSpaceliftAPIClientCA, "/nonexistent/ca.pem")
+
+	httpClient := &http.Client{}
+	err := configureTLS(httpClient)
+	assert.Error(t, err)
+}
+
+func TestConfigureTLS_InvalidCACert(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "bad.pem")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("not a certificate"), 0o600))
+
+	t.Setenv(EnvSpaceliftAPIClientCA, tmpFile)
+
+	httpClient := &http.Client{}
+	err := configureTLS(httpClient)
+	assert.ErrorIs(t, err, errEnvSpaceliftAPIClientCAParse)
+}
+
+// writeTempCA writes a self-signed PEM certificate to a temp file and returns the path.
+func writeTempCA(t *testing.T) string {
+	t.Helper()
+
+	// Minimal self-signed cert for testing CA pool loading (not used for real TLS).
+	// Generated with: openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes -days 36500
+	pem := []byte(`-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIUYz3GFhMGQwMz3GFhMGQwMTIzNDU2NzgwCgYIKoZIzj0EAwIw
+ETEPMA0GA1UEAwwGdGVzdGNhMCAXDTI0MDEwMTAwMDAwMFoYDzIwNjQwMTAxMDAw
+MDAwWjARMQ8wDQYDVQQDDAZ0ZXN0Y2EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
+AASKYz3GFhMGQwbnGTi7lakFOVkgn3hMG6jPGXSDfIaJbMGGaNGQwMjM0NTY3ODkw
+MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4
+MAoGCCqGSM49BAMCA0gAMEUCIQCtest1234567890AAAAABBBBBCCCCCDDDDEEEE
+FFFGGGHHHIIIJJJKKKLLLMMMAIgtest1234567890abcdefghijklmnopqrstuvw
+-----END CERTIFICATE-----`)
+
+	// Use a real system cert if available, otherwise use a proper self-signed one.
+	// /etc/ssl/cert.pem exists on macOS and contains real CA certs.
+	systemCert := "/etc/ssl/cert.pem"
+	if _, err := os.Stat(systemCert); err == nil {
+		return systemCert
+	}
+
+	tmpFile := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(tmpFile, pem, 0o600))
+	return tmpFile
+}

--- a/internal/cmd/authenticated/client_test.go
+++ b/internal/cmd/authenticated/client_test.go
@@ -1,11 +1,19 @@
 package authenticated
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,30 +93,28 @@ func TestConfigureTLS_InvalidCACert(t *testing.T) {
 	assert.ErrorIs(t, err, errEnvSpaceliftAPIClientCAParse)
 }
 
-// writeTempCA writes a self-signed PEM certificate to a temp file and returns the path.
+// writeTempCA generates a self-signed CA certificate and writes it to a temp file.
 func writeTempCA(t *testing.T) string {
 	t.Helper()
 
-	// Minimal self-signed cert for testing CA pool loading (not used for real TLS).
-	// Generated with: openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes -days 36500
-	pem := []byte(`-----BEGIN CERTIFICATE-----
-MIIBkTCB+wIUYz3GFhMGQwMz3GFhMGQwMTIzNDU2NzgwCgYIKoZIzj0EAwIw
-ETEPMA0GA1UEAwwGdGVzdGNhMCAXDTI0MDEwMTAwMDAwMFoYDzIwNjQwMTAxMDAw
-MDAwWjARMQ8wDQYDVQQDDAZ0ZXN0Y2EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
-AASKYz3GFhMGQwbnGTi7lakFOVkgn3hMG6jPGXSDfIaJbMGGaNGQwMjM0NTY3ODkw
-MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4
-MAoGCCqGSM49BAMCA0gAMEUCIQCtest1234567890AAAAABBBBBCCCCCDDDDEEEE
-FFFGGGHHHIIIJJJKKKLLLMMMAIgtest1234567890abcdefghijklmnopqrstuvw
------END CERTIFICATE-----`)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
 
-	// Use a real system cert if available, otherwise use a proper self-signed one.
-	// /etc/ssl/cert.pem exists on macOS and contains real CA certs.
-	systemCert := "/etc/ssl/cert.pem"
-	if _, err := os.Stat(systemCert); err == nil {
-		return systemCert
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "testca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
 	}
 
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
 	tmpFile := filepath.Join(t.TempDir(), "ca.pem")
-	require.NoError(t, os.WriteFile(tmpFile, pem, 0o600))
+	require.NoError(t, os.WriteFile(tmpFile, certPEM, 0o600))
 	return tmpFile
 }


### PR DESCRIPTION
## Summary

`configureTLS()` reads `SPACELIFT_API_TLS_CA` into `caFile` but passes the hardcoded string `"cacert"` to `os.ReadFile`, making the CA bundle feature non-functional. This also adds `SSL_CERT_FILE` as a fallback.

## Changes

### `internal/cmd/authenticated/client.go`

**Problem:** Line 84 calls `os.ReadFile("cacert")` instead of `os.ReadFile(caFile)`. Setting `SPACELIFT_API_TLS_CA=/etc/ssl/cert.pem` tries to read a literal file named `cacert` in the current directory.

**Solution:**
- Fix `os.ReadFile` to use the `caFile` variable
- Add `SSL_CERT_FILE` env var as a fallback when `SPACELIFT_API_TLS_CA` is not set
- `SPACELIFT_API_TLS_CA` takes precedence when both are set

**Impact:** Unblocks spacectl usage in sandboxed macOS environments (e.g., restricted CI runners, containerized dev environments) where Security.framework cannot access the Keychain, causing `x509: OSStatus -26276`. Setting `tls.Config.RootCAs` to a non-nil pool forces Go's pure-Go certificate verifier, bypassing the Security.framework dependency entirely.

### `internal/cmd/authenticated/client_test.go` (new)

Adds 6 test cases for `configureTLS`:
- No env vars set → nil RootCAs (default system behavior)
- `SPACELIFT_API_TLS_CA` set → RootCAs populated
- `SSL_CERT_FILE` fallback → RootCAs populated
- Both set → `SPACELIFT_API_TLS_CA` takes precedence
- Invalid CA path → error returned
- Invalid certificate content → `errEnvSpaceliftAPIClientCAParse`

## Net Impact

- Fixes a bug where `SPACELIFT_API_TLS_CA` has never worked
- Adds standard `SSL_CERT_FILE` support used by other Go tooling
- No breaking changes — existing behavior without env vars is unchanged

## Test plan

- [ ] `go test ./internal/cmd/authenticated/...` passes
- [ ] Set `SPACELIFT_API_TLS_CA=/etc/ssl/cert.pem` and verify `spacectl profile list` works in a sandboxed environment
- [ ] Verify no env vars set still uses system defaults