### PR TITLE
Allow mutations in the `api` command

### DIFF
--- a/internal/cmd/api/README.md
+++ b/internal/cmd/api/README.md
@@ -1,8 +1,8 @@
 # `spacectl api`
 
-`spacectl api` lets you run ad-hoc read-only GraphQL queries against the Spacelift API using your existing authentication.
+`spacectl api` lets you run ad-hoc GraphQL operations against the Spacelift API using your existing authentication.
 
-Mutations are not supported. For write operations, use the dedicated `spacectl` subcommands or the [Spacelift Terraform Provider](https://github.com/spacelift-io/terraform-provider-spacelift).
+Queries are allowed by default. Mutations require the explicit `--mutation` flag as a safety guard. Subscriptions are not supported.
 
 ## Usage
 
@@ -25,12 +25,20 @@ With variables:
 spacectl api --variables '{"id":"my-stack"}' 'query($id: ID!) { stack(id: $id) { id name } }'
 ```
 
+Mutations require `--mutation`. Bare mutation field selections are wrapped in `mutation { ... }` automatically:
+
+```bash
+spacectl api --mutation 'stackDelete(id: "my-stack") { id }'
+spacectl api --mutation 'mutation DeleteStack($id: ID!) { stackDelete(id: $id) { id } }' --variables '{"id":"my-stack"}'
+```
+
 From a file or stdin:
 
 ```bash
 spacectl api < query.graphql
 spacectl api --variables '{"id":"my-stack"}' < query.graphql
 cat query.graphql | spacectl api
+spacectl api --mutation < mutation.graphql
 ```
 
 ## Output

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -23,6 +23,10 @@ var (
 		Name:  "variables",
 		Usage: "JSON object with GraphQL variables",
 	}
+	flagMutation = &cli.BoolFlag{
+		Name:  "mutation",
+		Usage: "Allow and execute a GraphQL mutation",
+	}
 	flagRaw = &cli.BoolFlag{
 		Name:  "raw",
 		Usage: "Output response body without pretty-printing",
@@ -43,9 +47,9 @@ func Command() cmd.Command {
 				EarliestVersion: cmd.SupportedVersionAll,
 				Command: &cli.Command{
 					Before:      authenticated.Ensure,
-					Flags:       []cli.Flag{flagVariables, flagRaw, flagSchema},
-					Description: "Pass a read-only GraphQL query as a positional argument, or pipe via stdin.\nBare field selections are wrapped as query { ... } automatically.\nMutations and subscriptions are not supported. Read more: https://github.com/spacelift-io/spacectl/tree/main/internal/cmd/api/README.md",
-					ArgsUsage:   "[query]",
+					Flags:       []cli.Flag{flagVariables, flagMutation, flagRaw, flagSchema},
+					Description: "Pass a GraphQL document as a positional argument, or pipe via stdin.\nBare field selections are wrapped as query { ... } automatically.\nMutations require the --mutation flag. Subscriptions are not supported. Read more: https://github.com/spacelift-io/spacectl/tree/main/internal/cmd/api/README.md",
+					ArgsUsage:   "[document]",
 					Action:      run,
 				},
 			},
@@ -58,24 +62,28 @@ type apiRequest struct {
 	Variables map[string]any `json:"variables,omitempty"`
 }
 
-var errMutationsNotAllowed = errors.New("mutations are not supported by spacectl api")
+var errMutationFlagRequired = errors.New("this operation is a mutation; re-run with --mutation to allow write operations")
+var errMutationDocumentRequired = errors.New("--mutation requires a GraphQL mutation document")
+var errUnknownQueryDocument = errors.New(`could not determine GraphQL operation type; use 'query { stack(id: "x") { id } }' or 'stack(id: "x") { id }'`)
+var errUnknownMutationDocument = errors.New(`could not determine GraphQL operation type; when using --mutation, use 'mutation { stackDelete(id: "x") { id } }' or 'stackDelete(id: "x") { id }'`)
 
 func run(ctx context.Context, cliCmd *cli.Command) error {
 	var query string
 	if cliCmd.Bool(flagSchema.Name) {
+		if cliCmd.Bool(flagMutation.Name) {
+			return errors.New("--schema and --mutation cannot be used together")
+		}
 		query = introspectionQuery
 	} else {
 		var err error
-		query, err = resolveQuery(cliCmd)
+		query, err = resolveDocument(cliCmd)
 		if err != nil {
 			return err
 		}
 
-		// This is a hopefull check but it's enough for most cases.
-		// We could in theory allow mutations, but spacectl is not a great tool for
-		// that so we do not.
-		if isMutation(query) {
-			return errMutationsNotAllowed
+		query, err = normalizeDocument(query, cliCmd.Bool(flagMutation.Name))
+		if err != nil {
+			return err
 		}
 	}
 
@@ -124,9 +132,9 @@ func run(ctx context.Context, cliCmd *cli.Command) error {
 	return nil
 }
 
-func resolveQuery(cliCmd *cli.Command) (string, error) {
+func resolveDocument(cliCmd *cli.Command) (string, error) {
 	if args := strings.TrimSpace(strings.Join(cliCmd.Args().Slice(), " ")); args != "" {
-		return normalizeQuery(args), nil
+		return args, nil
 	}
 
 	if !isatty.IsTerminal(os.Stdin.Fd()) {
@@ -139,7 +147,7 @@ func resolveQuery(cliCmd *cli.Command) (string, error) {
 		}
 	}
 
-	return "", errors.New("query required: pass as argument or pipe via stdin")
+	return "", errors.New("document required: pass as argument or pipe via stdin")
 }
 
 func parseVariables(raw string) (map[string]any, error) {
@@ -153,17 +161,85 @@ func parseVariables(raw string) (map[string]any, error) {
 	return obj, nil
 }
 
-func normalizeQuery(query string) string {
-	lower := strings.ToLower(query)
-	if strings.HasPrefix(lower, "query") || strings.HasPrefix(lower, "mutation") || strings.HasPrefix(lower, "subscription") || strings.HasPrefix(query, "{") {
-		return query
+func normalizeDocument(document string, allowMutation bool) (string, error) {
+	switch start := firstSignificantToken(document); start {
+	case "mutation":
+		if !allowMutation {
+			return "", errMutationFlagRequired
+		}
+		return document, nil
+	case "query", "{":
+		if allowMutation {
+			return "", errMutationDocumentRequired
+		}
+		return document, nil
+	case "", "fragment", "subscription":
+		if allowMutation {
+			return "", errUnknownMutationDocument
+		}
+		return "", errUnknownQueryDocument
+	default:
+		if !isNameStart(start) {
+			if allowMutation {
+				return "", errUnknownMutationDocument
+			}
+			return "", errUnknownQueryDocument
+		}
+
+		if allowMutation {
+			return wrapOperation("mutation", document), nil
+		}
+		return wrapOperation("query", document), nil
 	}
-	return "query { " + query + " }"
 }
 
-func isMutation(query string) bool {
-	lower := strings.ToLower(strings.TrimSpace(query))
-	return strings.HasPrefix(lower, "mutation")
+func wrapOperation(kind, document string) string {
+	return kind + " { " + strings.TrimSpace(document) + " }"
+}
+
+func isNameStart(token string) bool {
+	if token == "" {
+		return false
+	}
+
+	c := token[0]
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+}
+
+func firstSignificantToken(document string) string {
+	i := 0
+	for i < len(document) {
+		switch document[i] {
+		case ' ', '\t', '\n', '\r', ',':
+			i++
+		case '#':
+			for i < len(document) && document[i] != '\n' {
+				i++
+			}
+		default:
+			if document[i] == '{' {
+				return "{"
+			}
+
+			start := i
+			for i < len(document) {
+				c := document[i]
+				if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+					i++
+					continue
+				}
+				break
+			}
+
+			if start == i {
+				return string(document[i])
+			}
+
+			return strings.ToLower(document[start:i])
+		}
+	}
+
+	return ""
 }
 
 func graphqlErrors(body []byte) string {

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -1,22 +1,121 @@
 package api
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestNormalizeQuery(t *testing.T) {
+func TestNormalizeDocument(t *testing.T) {
 	tests := []struct {
-		in, want string
+		name          string
+		in            string
+		allowMutation bool
+		want          string
+		wantErr       error
 	}{
-		{"{ viewer { id } }", "{ viewer { id } }"},
-		{"query { viewer { id } }", "query { viewer { id } }"},
-		{"mutation { deleteStack(id: \"x\") { id } }", "mutation { deleteStack(id: \"x\") { id } }"},
-		{"subscription { runs { id } }", "subscription { runs { id } }"},
-		{"stacks { id name }", "query { stacks { id name } }"},
+		{
+			name:    "query shorthand braces stay unchanged",
+			in:      "{ viewer { id } }",
+			want:    "{ viewer { id } }",
+			wantErr: nil,
+		},
+		{
+			name:    "query selection set shorthand",
+			in:      "stacks { id name }",
+			want:    "query { stacks { id name } }",
+			wantErr: nil,
+		},
+		{
+			name:    "full query syntax",
+			in:      "query { viewer { id } }",
+			want:    "query { viewer { id } }",
+			wantErr: nil,
+		},
+		{
+			name:          "mutation selection set shorthand",
+			in:            "stackDelete(id: \"x\") { id }",
+			allowMutation: true,
+			want:          "mutation { stackDelete(id: \"x\") { id } }",
+			wantErr:       nil,
+		},
+		{
+			name:    "field names containing keyword prefixes stay query shorthand",
+			in:      "mutation2Stack { id }",
+			want:    "query { mutation2Stack { id } }",
+			wantErr: nil,
+		},
+		{
+			name:          "full mutation syntax",
+			in:            "mutation DeleteStack($id: ID!) { stackDelete(id: $id) { id } }",
+			allowMutation: true,
+			want:          "mutation DeleteStack($id: ID!) { stackDelete(id: $id) { id } }",
+			wantErr:       nil,
+		},
+		{
+			name:    "mutation requires flag",
+			in:      "mutation { stackDelete(id: \"x\") { id } }",
+			wantErr: errMutationFlagRequired,
+		},
+		{
+			name:          "query rejected in mutation mode",
+			in:            "query { viewer { id } }",
+			allowMutation: true,
+			wantErr:       errMutationDocumentRequired,
+		},
+		{
+			name:          "query shorthand rejected in mutation mode",
+			in:            "{ viewer { id } }",
+			allowMutation: true,
+			wantErr:       errMutationDocumentRequired,
+		},
+		{
+			name:    "subscriptions rejected",
+			in:      "subscription { runs { id } }",
+			wantErr: errUnknownQueryDocument,
+		},
+		{
+			name:    "fragment must not be auto-wrapped",
+			in:      "fragment StackFields on Stack { id }",
+			wantErr: errUnknownQueryDocument,
+		},
 	}
+
 	for _, tc := range tests {
-		if got := normalizeQuery(tc.in); got != tc.want {
-			t.Errorf("normalizeQuery(%q) = %q, want %q", tc.in, got, tc.want)
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeDocument(tc.in, tc.allowMutation)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tc.wantErr)
+				}
+				if err.Error() != tc.wantErr.Error() {
+					t.Fatalf("got error %q, want %q", err, tc.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFirstSignificantToken(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"mutation { deleteStack(id: \"x\") { id } }", "mutation"},
+		{"mutation2Stack { id }", "mutation2stack"},
+		{"  # comment\nquery { viewer { id } }", "query"},
+		{"{ viewer { id } }", "{"},
+		{"...StackFields", "."},
+	}
+
+	for _, tc := range tests {
+		if got := firstSignificantToken(tc.in); got != tc.want {
+			t.Errorf("firstSignificantToken(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
 }
@@ -49,24 +148,6 @@ func TestGraphqlErrors(t *testing.T) {
 	}
 	if msg := graphqlErrors([]byte(`{"errors":[{"message":"a"},{"message":"b"}]}`)); msg != "a; b" {
 		t.Errorf("got %q", msg)
-	}
-}
-
-func TestIsMutation(t *testing.T) {
-	tests := []struct {
-		in   string
-		want bool
-	}{
-		{"mutation { deleteStack(id: \"x\") { id } }", true},
-		{"  Mutation { foo }", true},
-		{"query { stacks { id } }", false},
-		{"{ viewer { id } }", false},
-		{"stacks { id }", false},
-	}
-	for _, tc := range tests {
-		if got := isMutation(tc.in); got != tc.want {
-			t.Errorf("isMutation(%q) = %v, want %v", tc.in, got, tc.want)
-		}
 	}
 }
 


### PR DESCRIPTION
This allows `spacectl api` to execute arbitrary mutations, but only when `--mutation` is passed explicitly.

It supports both shorthand and full mutation syntax:

```bash
spacectl api --mutation 'stackDelete(id: "x") { id }'
spacectl api --mutation 'mutation { stackDelete(id: "x") { id } }'
```