### PR TITLE
feat: Implement list and discard for workerpools queue

### DIFF
--- a/internal/cmd/workerpools/cmd.go
+++ b/internal/cmd/workerpools/cmd.go
@@ -126,6 +126,75 @@ func Command() cmd.Command {
 							},
 						},
 					},
+					{
+						Name:  "queue",
+						Usage: "Inspect and manage runs waiting in this worker pool's scheduler queue.",
+						Versions: []cmd.VersionedCommand{
+							{
+								EarliestVersion: cmd.SupportedVersionAll,
+								Command:         &cli.Command{},
+							},
+						},
+						Subcommands: []cmd.Command{
+							{
+								Name:  "list",
+								Usage: "Lists runs currently scheduled for the worker pool.",
+								Versions: []cmd.VersionedCommand{
+									{
+										EarliestVersion: cmd.SupportedVersionAll,
+										Command: &cli.Command{
+											Flags: []cli.Flag{
+												flagWorkerPoolIDOptional,
+												flagQueueLimit,
+												flagQueueAfter,
+												flagQueueSearch,
+												flagQueueState,
+												flagQueueExcludeState,
+												flagQueueStack,
+												flagQueueRunType,
+												flagQueueDriftDetection,
+												flagQueuePrioritized,
+												flagQueueCommit,
+												cmd.FlagOutputFormat,
+											},
+											Action:    (&listQueueCommand{}).listQueue,
+											Before:    authenticated.Ensure,
+											ArgsUsage: cmd.EmptyArgsUsage,
+										},
+									},
+								},
+							},
+							{
+								Name:  "discard",
+								Usage: "Discards queued runs for the worker pool.",
+								Versions: []cmd.VersionedCommand{
+									{
+										EarliestVersion: cmd.SupportedVersionAll,
+										Command: &cli.Command{
+											Flags: []cli.Flag{
+												flagWorkerPoolIDOptional,
+												flagQueueLimit,
+												flagQueueAfter,
+												flagQueueSearch,
+												flagQueueState,
+												flagQueueExcludeState,
+												flagQueueStack,
+												flagQueueRunType,
+												flagQueueDriftDetection,
+												flagQueuePrioritized,
+												flagQueueCommit,
+												flagQueueRun,
+												flagQueueYes,
+											},
+											Action:    (&discardQueueCommand{}).discardQueue,
+											Before:    authenticated.Ensure,
+											ArgsUsage: cmd.EmptyArgsUsage,
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/internal/cmd/workerpools/flags.go
+++ b/internal/cmd/workerpools/flags.go
@@ -26,9 +26,9 @@ var flagWaitUntilDrained = &cli.BoolFlag{
 }
 
 var flagQueueLimit = &cli.IntFlag{
-	Name:    "limit",
-	Usage:   "Maximum number of schedulable runs to fetch",
-	Value:   100,
+	Name:  "limit",
+	Usage: "Maximum number of schedulable runs to fetch",
+	Value: 100,
 }
 
 var flagQueueAfter = &cli.StringFlag{

--- a/internal/cmd/workerpools/flags.go
+++ b/internal/cmd/workerpools/flags.go
@@ -2,6 +2,11 @@ package workerpools
 
 import "github.com/urfave/cli/v3"
 
+var flagWorkerPoolIDOptional = &cli.StringFlag{
+	Name:  "pool-id",
+	Usage: "[Optional] ID of the worker pool; omit to use the shared public worker pool",
+}
+
 var flagPoolIDNamed = &cli.StringFlag{
 	Name:     "pool-id",
 	Usage:    "[Required] ID of the worker pool",
@@ -18,4 +23,69 @@ var flagWaitUntilDrained = &cli.BoolFlag{
 	Name:     "wait-until-drained",
 	Usage:    "Wait until the worker is drained",
 	Required: false,
+}
+
+var flagQueueLimit = &cli.IntFlag{
+	Name:    "limit",
+	Usage:   "Maximum number of schedulable runs to fetch",
+	Value:   100,
+}
+
+var flagQueueAfter = &cli.StringFlag{
+	Name:  "after",
+	Usage: "Pagination cursor from a previous queue list (JSON output includes pageInfo.endCursor)",
+}
+
+var flagQueueSearch = &cli.StringFlag{
+	Name:  "search",
+	Usage: "Full-text search across schedulable runs",
+}
+
+var flagQueueState = &cli.StringSliceFlag{
+	Name:    "state",
+	Usage:   "Only include runs in this state (repeatable), e.g. QUEUED",
+	Sources: cli.EnvVars("SPACECTL_QUEUE_STATE"),
+}
+
+var flagQueueExcludeState = &cli.StringSliceFlag{
+	Name:    "exclude-state",
+	Usage:   "Exclude runs in this state (repeatable)",
+	Sources: cli.EnvVars("SPACECTL_QUEUE_EXCLUDE_STATE"),
+}
+
+var flagQueueStack = &cli.StringFlag{
+	Name:  "stack",
+	Usage: "Only include runs for this stack id (slug); matched client-side after listing from the API",
+}
+
+var flagQueueRunType = &cli.StringSliceFlag{
+	Name:    "run-type",
+	Usage:   "Only include runs of this type (repeatable); values are uppercased for the API (e.g. tracked and TRACKED both work)",
+	Sources: cli.EnvVars("SPACECTL_QUEUE_RUN_TYPE"),
+}
+
+var flagQueueDriftDetection = &cli.StringFlag{
+	Name:  "drift-detection",
+	Usage: "Only include runs with this drift detection setting (true or false); matched client-side (not a search predicate)",
+}
+
+var flagQueuePrioritized = &cli.StringFlag{
+	Name:  "prioritized",
+	Usage: "Only include runs where isPrioritized is true or false (matches API Run.isPrioritized)",
+}
+
+var flagQueueCommit = &cli.StringFlag{
+	Name:  "commit",
+	Usage: "Only include runs whose commit hash contains this substring (case-insensitive, matched client-side)",
+}
+
+var flagQueueRun = &cli.StringFlag{
+	Name:  "run",
+	Usage: "When discarding a single run, its id (requires --stack)",
+}
+
+var flagQueueYes = &cli.BoolFlag{
+	Name:  "yes",
+	Usage: "Required to confirm filter-based discard of multiple runs",
+	Value: false,
 }

--- a/internal/cmd/workerpools/queue.go
+++ b/internal/cmd/workerpools/queue.go
@@ -1,0 +1,499 @@
+package workerpools
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/shurcooL/graphql"
+	"github.com/urfave/cli/v3"
+
+	"github.com/spacelift-io/spacectl/client/structs"
+	"github.com/spacelift-io/spacectl/internal/cmd"
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
+)
+
+const (
+	maxSchedulableRunsLimit  = 100
+	maxClientFilterScanPages = 100
+)
+
+type schedulableRunsConnection struct {
+	Edges    []schedulableRunEdge `graphql:"edges"`
+	PageInfo structs.PageInfo     `graphql:"pageInfo"`
+}
+
+type schedulableRunEdge struct {
+	Node struct {
+		StackID  string `graphql:"stackId" json:"stackId"`
+		Position int    `graphql:"position" json:"position"`
+		Run      struct {
+			ID             string `graphql:"id" json:"id"`
+			CreatedAt      int    `graphql:"createdAt" json:"createdAt"`
+			State          string `graphql:"state" json:"state"`
+			Type           string `graphql:"type" json:"type"`
+			Title          string `graphql:"title" json:"title"`
+			DriftDetection bool   `graphql:"driftDetection" json:"driftDetection"`
+			IsPrioritized  bool   `graphql:"isPrioritized" json:"isPrioritized"`
+			Commit         struct {
+				Hash string `graphql:"hash" json:"hash"`
+			} `graphql:"commit" json:"commit"`
+		} `graphql:"run" json:"run"`
+	} `graphql:"node" json:"node"`
+}
+
+type queueListJSON struct {
+	Runs     []queueListRunJSON `json:"runs"`
+	PageInfo structs.PageInfo   `json:"pageInfo"`
+}
+
+type queueListRunJSON struct {
+	StackID  string               `json:"stackId"`
+	Position int                  `json:"position"`
+	Run      queueListRunBodyJSON `json:"run"`
+}
+
+type queueListRunBodyJSON struct {
+	ID             string `json:"id"`
+	CreatedAt      int    `json:"createdAt"`
+	State          string `json:"state"`
+	Type           string `json:"type"`
+	Title          string `json:"title"`
+	DriftDetection bool   `json:"driftDetection"`
+	Priority       bool   `json:"priority"`
+	CommitHash     string `json:"commitHash"`
+}
+
+// schedulableClientFilter applies filters that searchSchedulableRuns does not support as predicates
+// (stack id, drift, commit substring). See collectSchedulableRuns.
+type schedulableClientFilter struct {
+	stackID   string
+	drift     *bool
+	commitSub string
+}
+
+func (f *schedulableClientFilter) active() bool {
+	if f == nil {
+		return false
+	}
+	return f.stackID != "" || f.drift != nil || f.commitSub != ""
+}
+
+func (f *schedulableClientFilter) matches(edge schedulableRunEdge) bool {
+	if f == nil || !f.active() {
+		return true
+	}
+	if f.stackID != "" && !strings.EqualFold(strings.TrimSpace(edge.Node.StackID), strings.TrimSpace(f.stackID)) {
+		return false
+	}
+	if f.drift != nil && edge.Node.Run.DriftDetection != *f.drift {
+		return false
+	}
+	if f.commitSub != "" {
+		h := strings.ToLower(edge.Node.Run.Commit.Hash)
+		if !strings.Contains(h, strings.ToLower(strings.TrimSpace(f.commitSub))) {
+			return false
+		}
+	}
+	return true
+}
+
+type listQueueCommand struct{}
+
+type discardQueueCommand struct{}
+
+func (c *listQueueCommand) listQueue(ctx context.Context, cliCmd *cli.Command) error {
+	outputFormat, err := cmd.GetOutputFormat(cliCmd)
+	if err != nil {
+		return err
+	}
+
+	base, cf, limit, err := queueSearchPlan(cliCmd)
+	if err != nil {
+		return err
+	}
+
+	edges, pageInfo, err := collectSchedulableRuns(ctx, cliCmd.String(flagWorkerPoolIDOptional.Name), base, cf, limit)
+	if err != nil {
+		return err
+	}
+
+	switch outputFormat {
+	case cmd.OutputFormatTable:
+		return c.showQueueTable(edges, pageInfo)
+	case cmd.OutputFormatJSON:
+		return c.showQueueJSON(edges, pageInfo)
+	default:
+		return fmt.Errorf("unknown output format: %v", outputFormat)
+	}
+}
+
+func (c *listQueueCommand) showQueueJSON(edges []schedulableRunEdge, pageInfo structs.PageInfo) error {
+	runs := make([]queueListRunJSON, 0, len(edges))
+	for _, edge := range edges {
+		r := edge.Node.Run
+		runs = append(runs, queueListRunJSON{
+			StackID:  edge.Node.StackID,
+			Position: edge.Node.Position,
+			Run: queueListRunBodyJSON{
+				ID:             r.ID,
+				CreatedAt:      r.CreatedAt,
+				State:          r.State,
+				Type:           r.Type,
+				Title:          r.Title,
+				DriftDetection: r.DriftDetection,
+				Priority:       r.IsPrioritized,
+				CommitHash:     r.Commit.Hash,
+			},
+		})
+	}
+	return cmd.OutputJSON(queueListJSON{Runs: runs, PageInfo: pageInfo})
+}
+
+func (c *listQueueCommand) showQueueTable(edges []schedulableRunEdge, pageInfo structs.PageInfo) error {
+	tableData := [][]string{{"#", "Stack ID", "Run ID", "Commit", "Drift detection", "Priority", "State", "Type", "Title", "Created At"}}
+	for _, edge := range edges {
+		tm := time.Unix(int64(edge.Node.Run.CreatedAt), 0)
+		title := edge.Node.Run.Title
+		if title == "" {
+			title = "-"
+		}
+		commit := edge.Node.Run.Commit.Hash
+		if commit == "" {
+			commit = "-"
+		} else {
+			commit = cmd.HumanizeGitHash(commit)
+		}
+		tableData = append(tableData, []string{
+			fmt.Sprint(edge.Node.Position),
+			edge.Node.StackID,
+			edge.Node.Run.ID,
+			commit,
+			fmt.Sprintf("%t", edge.Node.Run.DriftDetection),
+			fmt.Sprintf("%t", edge.Node.Run.IsPrioritized),
+			edge.Node.Run.State,
+			edge.Node.Run.Type,
+			title,
+			tm.Format(time.RFC3339),
+		})
+	}
+	if err := cmd.OutputTable(tableData, true); err != nil {
+		return err
+	}
+	if pageInfo.HasNextPage && pageInfo.EndCursor != "" {
+		fmt.Fprintf(os.Stderr, "\nMore results available. Pass --after=%q to fetch the next page.\n", pageInfo.EndCursor)
+	}
+	return nil
+}
+
+func (c *discardQueueCommand) discardQueue(ctx context.Context, cliCmd *cli.Command) error {
+	runID := cliCmd.String(flagQueueRun.Name)
+	if runID != "" {
+		stackID := cliCmd.String(flagQueueStack.Name)
+		if stackID == "" {
+			return fmt.Errorf("--stack is required when --run is set")
+		}
+		return discardSingleQueuedRun(ctx, stackID, runID)
+	}
+
+	base, cf, limit, err := queueSearchPlan(cliCmd)
+	if err != nil {
+		return err
+	}
+
+	edges, _, err := collectSchedulableRuns(ctx, cliCmd.String(flagWorkerPoolIDOptional.Name), base, cf, limit)
+	if err != nil {
+		return err
+	}
+
+	if len(edges) == 0 {
+		fmt.Println("No matching runs in the queue.")
+		return nil
+	}
+
+	if !cliCmd.Bool(flagQueueYes.Name) {
+		return fmt.Errorf("refusing to discard %d run(s) without --yes", len(edges))
+	}
+
+	for _, edge := range edges {
+		discardedID, err := mutateRunDiscard(ctx, edge.Node.StackID, edge.Node.Run.ID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to discard run %q for stack %q", edge.Node.Run.ID, edge.Node.StackID)
+		}
+		fmt.Printf("Discarded run %s\n", discardedID)
+		fmt.Println("The run can be visited at", authenticated.Client().URL(
+			"/stack/%s/run/%s",
+			edge.Node.StackID,
+			discardedID,
+		))
+	}
+
+	return nil
+}
+
+func discardSingleQueuedRun(ctx context.Context, stackID, runID string) error {
+	discardedID, err := mutateRunDiscard(ctx, stackID, runID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("You have successfully discarded a deployment")
+	fmt.Println("The run can be visited at", authenticated.Client().URL(
+		"/stack/%s/run/%s",
+		stackID,
+		discardedID,
+	))
+
+	return nil
+}
+
+func mutateRunDiscard(ctx context.Context, stackID, runID string) (string, error) {
+	var mutation struct {
+		RunDiscard struct {
+			ID string `graphql:"id"`
+		} `graphql:"runDiscard(stack: $stack, run: $run)"`
+	}
+
+	variables := map[string]any{
+		"stack": graphql.ID(stackID),
+		"run":   graphql.ID(runID),
+	}
+
+	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {
+		return "", err
+	}
+
+	return mutation.RunDiscard.ID, nil
+}
+
+func collectSchedulableRuns(
+	ctx context.Context,
+	workerPoolID string,
+	base structs.SearchInput,
+	cf *schedulableClientFilter,
+	limit int,
+) ([]schedulableRunEdge, structs.PageInfo, error) {
+	if cf == nil || !cf.active() {
+		inp := base
+		inp.First = graphql.NewInt(graphql.Int(limit)) //nolint:gosec
+		return searchSchedulableRuns(ctx, workerPoolID, inp)
+	}
+
+	var out []schedulableRunEdge
+	var lastPI structs.PageInfo
+	after := base.After
+
+	for page := 0; page < maxClientFilterScanPages; page++ {
+		inp := base
+		inp.First = graphql.NewInt(graphql.Int(maxSchedulableRunsLimit)) //nolint:gosec
+		inp.After = after
+
+		edges, pi, err := searchSchedulableRuns(ctx, workerPoolID, inp)
+		if err != nil {
+			return nil, structs.PageInfo{}, err
+		}
+		lastPI = pi
+
+		for _, edge := range edges {
+			if !cf.matches(edge) {
+				continue
+			}
+			out = append(out, edge)
+			if len(out) >= limit {
+				return out, lastPI, nil
+			}
+		}
+
+		if !pi.HasNextPage || pi.EndCursor == "" {
+			break
+		}
+		s := graphql.String(pi.EndCursor)
+		after = &s
+	}
+
+	return out, lastPI, nil
+}
+
+func searchSchedulableRuns(ctx context.Context, workerPoolID string, input structs.SearchInput) ([]schedulableRunEdge, structs.PageInfo, error) {
+	if workerPoolID != "" {
+		var query struct {
+			WorkerPool *struct {
+				Runs schedulableRunsConnection `graphql:"searchSchedulableRuns(input: $input)"`
+			} `graphql:"workerPool(id: $id)"`
+		}
+
+		variables := map[string]any{
+			"id":    graphql.ID(workerPoolID),
+			"input": input,
+		}
+
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+			return nil, structs.PageInfo{}, errors.Wrap(err, "failed to query schedulable runs")
+		}
+
+		if query.WorkerPool == nil {
+			return nil, structs.PageInfo{}, fmt.Errorf("worker pool with id %q not found", workerPoolID)
+		}
+
+		return query.WorkerPool.Runs.Edges, query.WorkerPool.Runs.PageInfo, nil
+	}
+
+	var query struct {
+		WorkerPool struct {
+			Runs schedulableRunsConnection `graphql:"searchSchedulableRuns(input: $input)"`
+		} `graphql:"publicWorkerPool"`
+	}
+
+	variables := map[string]any{"input": input}
+
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+		return nil, structs.PageInfo{}, errors.Wrap(err, "failed to query schedulable runs")
+	}
+
+	return query.WorkerPool.Runs.Edges, query.WorkerPool.Runs.PageInfo, nil
+}
+
+func queueSearchPlan(cliCmd *cli.Command) (structs.SearchInput, *schedulableClientFilter, int, error) {
+	limit := cliCmd.Int(flagQueueLimit.Name)
+	if limit < 1 || limit > maxSchedulableRunsLimit {
+		return structs.SearchInput{}, nil, 0, fmt.Errorf("limit must be between 1 and %d", maxSchedulableRunsLimit)
+	}
+
+	input := structs.SearchInput{
+		OrderBy: &structs.QueryOrder{
+			Field:     graphql.String("position"),
+			Direction: graphql.String("ASC"),
+		},
+	}
+
+	if after := cliCmd.String(flagQueueAfter.Name); after != "" {
+		s := graphql.String(after)
+		input.After = &s
+	}
+
+	if ft := cliCmd.String(flagQueueSearch.Name); ft != "" {
+		s := graphql.String(ft)
+		input.FullTextSearch = &s
+	}
+
+	preds, err := buildAPISchedulableRunPredicates(cliCmd)
+	if err != nil {
+		return structs.SearchInput{}, nil, 0, err
+	}
+	if len(preds) > 0 {
+		input.Predicates = &preds
+	}
+
+	cf, err := clientFilterFromFlags(cliCmd)
+	if err != nil {
+		return structs.SearchInput{}, nil, 0, err
+	}
+
+	return input, cf, limit, nil
+}
+
+func clientFilterFromFlags(cliCmd *cli.Command) (*schedulableClientFilter, error) {
+	f := &schedulableClientFilter{}
+	if s := strings.TrimSpace(cliCmd.String(flagQueueStack.Name)); s != "" {
+		f.stackID = s
+	}
+	if cliCmd.IsSet(flagQueueDriftDetection.Name) {
+		b, err := parseQueueOptionalBool(cliCmd.String(flagQueueDriftDetection.Name))
+		if err != nil {
+			return nil, err
+		}
+		f.drift = &b
+	}
+	if c := strings.TrimSpace(cliCmd.String(flagQueueCommit.Name)); c != "" {
+		f.commitSub = c
+	}
+	return f, nil
+}
+
+// buildAPISchedulableRunPredicates returns only predicates supported by searchSchedulableRuns.
+// Stack, drift, and commit are applied client-side (see schedulableClientFilter).
+func buildAPISchedulableRunPredicates(cliCmd *cli.Command) ([]structs.QueryPredicate, error) {
+	var preds []structs.QueryPredicate
+
+	if cliCmd.IsSet(flagQueuePrioritized.Name) {
+		wantPrioritized, err := parseQueueOptionalBool(cliCmd.String(flagQueuePrioritized.Name))
+		if err != nil {
+			return nil, err
+		}
+		preds = append(preds, structs.QueryPredicate{
+			Field: graphql.String("isPrioritized"),
+			Constraint: structs.QueryFieldConstraint{
+				BooleanEquals: &[]graphql.Boolean{graphql.Boolean(wantPrioritized)},
+			},
+		})
+	}
+
+	states := cliCmd.StringSlice(flagQueueState.Name)
+	if len(states) > 0 {
+		enums := make([]graphql.String, 0, len(states))
+		for _, st := range states {
+			st = strings.TrimSpace(st)
+			if st != "" {
+				enums = append(enums, graphql.String(strings.ToUpper(st)))
+			}
+		}
+		if len(enums) > 0 {
+			preds = append(preds, structs.QueryPredicate{
+				Field: graphql.String("state"),
+				Constraint: structs.QueryFieldConstraint{
+					EnumEquals: &enums,
+				},
+			})
+		}
+	}
+
+	for _, st := range cliCmd.StringSlice(flagQueueExcludeState.Name) {
+		st = strings.TrimSpace(st)
+		if st == "" {
+			continue
+		}
+		enum := graphql.String(strings.ToUpper(st))
+		preds = append(preds, structs.QueryPredicate{
+			Field:   graphql.String("state"),
+			Exclude: true,
+			Constraint: structs.QueryFieldConstraint{
+				EnumEquals: &[]graphql.String{enum},
+			},
+		})
+	}
+
+	runTypes := cliCmd.StringSlice(flagQueueRunType.Name)
+	if len(runTypes) > 0 {
+		enums := make([]graphql.String, 0, len(runTypes))
+		for _, rt := range runTypes {
+			rt = strings.TrimSpace(rt)
+			if rt != "" {
+				enums = append(enums, graphql.String(strings.ToUpper(rt)))
+			}
+		}
+		if len(enums) > 0 {
+			preds = append(preds, structs.QueryPredicate{
+				Field: graphql.String("type"),
+				Constraint: structs.QueryFieldConstraint{
+					EnumEquals: &enums,
+				},
+			})
+		}
+	}
+
+	return preds, nil
+}
+
+func parseQueueOptionalBool(s string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "1", "yes":
+		return true, nil
+	case "false", "0", "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean %q (use true or false)", s)
+	}
+}


### PR DESCRIPTION
## Description

Adds `workerpool worker queue` command to manage runs in a worker pool’s schedulable queue from the CLI:
- `queue list` shows queued runs (table or JSON).
- `queue discard` supports a single run via `--stack` and `--run`, or bulk discard with the same filters as list plus `--yes` to confirm.

Uses `searchSchedulableRuns` on `publicWorkerPool` (no `--pool-id`) or `workerPool(id: …)` for a private pool, and `runDiscard(stack:, run:)` for discard. API search predicates include `isPrioritized`, `state`, and `type`; `--stack`, `--drift-detection`, and `--commit` are applied client-side after paging results so `--limit` still applies for bulk discard when those filters are used.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- New subcommands: `spacectl workerpool worker queue list` and `spacectl workerpool worker queue discard`
- `internal/cmd/workerpools/queue.go` — GraphQL queries, list/discard actions, `collectSchedulableRuns` (pagination + client-side filters), API-only predicates in `buildAPISchedulableRunPredicates`
- `internal/cmd/workerpools/cmd.go` — command registration
- `internal/cmd/workerpools/flags.go` — queue-related flags and help text

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [x] All existing tests pass (`go test ./...`)

## Screenshots (if applicable)
N/A (CLI only).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Related Issues
Closes #
Fixes #
Related to <https://feedback.spacelift.io/p/allow-manage-runs-with-spacectl>