### PR TITLE
Add a force-apply flag on stack deploy

### DIFF
--- a/client/structs/force_apply_mode.go
+++ b/client/structs/force_apply_mode.go
@@ -1,0 +1,10 @@
+package structs
+
+// ForceApplyMode selects how a force-applied tracked run propagates to dependencies.
+type ForceApplyMode string
+
+// NewForceApplyMode returns a pointer suitable for the runTrigger mutation's forceApply argument.
+func NewForceApplyMode(in string) *ForceApplyMode {
+	out := ForceApplyMode(in)
+	return &out
+}

--- a/internal/cmd/stack/flags.go
+++ b/internal/cmd/stack/flags.go
@@ -95,6 +95,12 @@ var flagRuntimeConfig = &cli.StringFlag{
 	Required: false,
 }
 
+var flagForceApply = &cli.StringFlag{
+	Name:     "force-apply",
+	Usage:    "[Optional] Force apply: `single` (this stack only) or `cascade` (this stack and all dependencies)",
+	Required: false,
+}
+
 var flagNoTail = &cli.BoolFlag{
 	Name:  "no-tail",
 	Usage: "Indicate whether not to tail the run",

--- a/internal/cmd/stack/run_trigger.go
+++ b/internal/cmd/stack/run_trigger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli/v3"
@@ -41,10 +42,18 @@ func runTrigger(spaceliftType, humanType string) cli.ActionFunc {
 			}
 		}
 
+		var forceApply *structs.ForceApplyMode
+		if cliCmd.IsSet(flagForceApply.Name) {
+			forceApply, err = parseForceApplyMode(cliCmd.String(flagForceApply.Name))
+			if err != nil {
+				return err
+			}
+		}
+
 		var mutation struct {
 			RunTrigger struct {
 				ID string `graphql:"id"`
-			} `graphql:"runTrigger(stack: $stack, commitSha: $sha, runType: $type, runtimeConfig: $runtimeConfig)"`
+			} `graphql:"runTrigger(stack: $stack, commitSha: $sha, runType: $type, runtimeConfig: $runtimeConfig, forceApply: $forceApply)"`
 		}
 
 		variables := map[string]any{
@@ -52,6 +61,7 @@ func runTrigger(spaceliftType, humanType string) cli.ActionFunc {
 			"sha":           (*graphql.String)(nil),
 			"type":          structs.NewRunType(spaceliftType),
 			"runtimeConfig": runtimeConfigInput,
+			"forceApply":    forceApply,
 		}
 
 		if cliCmd.IsSet(flagCommitSHA.Name) {
@@ -113,5 +123,16 @@ func runTrigger(spaceliftType, humanType string) cli.ActionFunc {
 		}
 
 		return terminal.Error()
+	}
+}
+
+func parseForceApplyMode(s string) (*structs.ForceApplyMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "single":
+		return structs.NewForceApplyMode("SINGLE"), nil
+	case "cascade":
+		return structs.NewForceApplyMode("CASCADE"), nil
+	default:
+		return nil, fmt.Errorf("invalid --force-apply value %q (use single or cascade)", s)
 	}
 }

--- a/internal/cmd/stack/stack.go
+++ b/internal/cmd/stack/stack.go
@@ -155,6 +155,7 @@ func Command() cmd.Command {
 								flagTail,
 								flagAutoConfirm,
 								flagRuntimeConfig,
+								flagForceApply,
 							},
 							Action:    runTrigger("TRACKED", "deployment"),
 							Before:    authenticated.Ensure,


### PR DESCRIPTION
## Description

Adds an optional `--force-apply` flag to `spacectl stack deploy`, mapping to the GraphQL `runTrigger` `forceApply` argument (`ForceApplyMode`: `SINGLE` for this stack only, `CASCADE` for this stack and its dependencies).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made
- Introduced `ForceApplyMode` helper in `client/structs/force_apply_mode.go` (aligned with `RunType` usage).
- Added `flagForceApply` in `internal/cmd/stack/flags.go` with usage text for `single` vs `cascade`.
- Extended `runTrigger` in `internal/cmd/stack/run_trigger.go` to pass `forceApply: $forceApply` when `--force-apply` is set; validates allowed values.
- Registered the flag only on `stack deploy` in `internal/cmd/stack/stack.go` (not on `stack preview`).

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [x] All existing tests pass

## Screenshots (if applicable)

N/A — CLI flag only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Related Issues

Closes #(issue number)
Fixes #(issue number)
Related to #(issue number)