### PR TITLE
feat(stack): include additionalProjectGlobs in stack show output

### DIFF
--- a/internal/cmd/stack/show.go
+++ b/internal/cmd/stack/show.go
@@ -78,17 +78,18 @@ type showStackQuery struct {
 				Owner string `graphql:"owner" json:"owner,omitempty"`
 			} `graphql:"module" json:"module"`
 		} `graphql:"moduleVersionsUsed" json:"moduleVersionsUsed,omitempty"`
-		Name             string `graphql:"name" json:"name,omitempty"`
-		Namespace        string `graphql:"namespace" json:"namespace,omitempty"`
-		ProjectRoot      string `graphql:"projectRoot" json:"projectRoot,omitempty"`
-		Provider         string `graphql:"provider" json:"provider,omitempty"`
-		Repository       string `graphql:"repository" json:"repository,omitempty"`
-		RunnerImage      string `graphql:"runnerImage" json:"runnerImage,omitempty"`
-		Starred          bool   `graphql:"starred" json:"starred"`
-		State            string `graphql:"state" json:"state,omitempty"`
-		StateSetAt       int64  `graphql:"stateSetAt" json:"stateSetAt,omitempty"`
-		TerraformVersion string `graphql:"terraformVersion" json:"terraformVersion,omitempty"`
-		TrackedCommit    struct {
+		Name                   string   `graphql:"name" json:"name,omitempty"`
+		Namespace              string   `graphql:"namespace" json:"namespace,omitempty"`
+		ProjectRoot            string   `graphql:"projectRoot" json:"projectRoot,omitempty"`
+		AdditionalProjectGlobs []string `graphql:"additionalProjectGlobs" json:"additionalProjectGlobs,omitempty"`
+		Provider               string   `graphql:"provider" json:"provider,omitempty"`
+		Repository             string   `graphql:"repository" json:"repository,omitempty"`
+		RunnerImage            string   `graphql:"runnerImage" json:"runnerImage,omitempty"`
+		Starred                bool     `graphql:"starred" json:"starred"`
+		State                  string   `graphql:"state" json:"state,omitempty"`
+		StateSetAt             int64    `graphql:"stateSetAt" json:"stateSetAt,omitempty"`
+		TerraformVersion       string   `graphql:"terraformVersion" json:"terraformVersion,omitempty"`
+		TrackedCommit          struct {
 			AuthorLogin string `graphql:"authorLogin" json:"authorLogin,omitempty"`
 			AuthorName  string `graphql:"authorName" json:"authorName,omitempty"`
 			Hash        string `graphql:"hash" json:"hash,omitempty"`
@@ -235,6 +236,7 @@ func (c *showStackCommand) outputBehaviorSettings(query showStackQuery) error {
 		{"Autoretry", fmt.Sprint(query.Stack.Autoretry)},
 		{"Local preview enabled", fmt.Sprint(query.Stack.LocalPreviewEnabled)},
 		{"Project root", fmt.Sprint(query.Stack.ProjectRoot)},
+		{"Additional project globs", strings.Join(query.Stack.AdditionalProjectGlobs, ", ")},
 		{"Runner image", stringWithDefault(query.Stack.RunnerImage, "default")},
 	}
 


### PR DESCRIPTION
## Description

Adds `additionalProjectGlobs` to the `stack show` command output. The field was available in the Spacelift GraphQL API but missing from the query struct, causing it to be silently omitted from both JSON and table output.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- Added `AdditionalProjectGlobs []string` to the `showStackQuery` struct in `internal/cmd/stack/show.go` with `graphql:` and `json:` tags
- Added an **Additional project globs** row to the table output in `outputBehaviorSettings()`
- JSON output picks up the field automatically via the struct tag

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [x] All existing tests pass

## Screenshots (if applicable)

N/A — field is additive, no visual regression.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] My changes generate no new warnings

## Related Issues

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)