### PR TITLE
feat: Add no-browser option to login command

### DIFF
--- a/internal/cmd/profile/flags.go
+++ b/internal/cmd/profile/flags.go
@@ -69,6 +69,16 @@ var flagEndpoint = &cli.StringFlag{
 	Sources:  cli.EnvVars("SPACECTL_LOGIN_ENDPOINT"),
 }
 
+var noBrowser bool
+var flagNoBrowser = &cli.BoolFlag{
+	Name:        "no-browser",
+	Usage:       "[Optional] do not open the authentication URL in a browser",
+	Required:    false,
+	Value:       false,
+	Destination: &noBrowser,
+	Sources:     cli.EnvVars("SPACECTL_NO_BROWSER"),
+}
+
 const (
 	usageViewCSVTimeFormat   = "2006-01-02"
 	usageViewCSVDefaultRange = time.Duration(-1*30*24) * time.Hour

--- a/internal/cmd/profile/login_command.go
+++ b/internal/cmd/profile/login_command.go
@@ -33,6 +33,7 @@ func loginCommand() *cli.Command {
 			flagBindHost,
 			flagBindPort,
 			flagEndpoint,
+			flagNoBrowser,
 		},
 	}
 }
@@ -193,7 +194,9 @@ func loginUsingWebBrowser(ctx context.Context, _ *cli.Command, creds *session.St
 	fmt.Printf("\nOpening browser to %s\n\n", handler.AuthenticationURL)
 
 	// Attempt to automatically open the URL in the user's browser
-	if err := browser.OpenURL(handler.AuthenticationURL); err != nil {
+	if noBrowser {
+		fmt.Printf("Please open the following URL in your browser to complete login:\n%s\n\n", handler.AuthenticationURL)
+	} else if err := browser.OpenURL(handler.AuthenticationURL); err != nil {
 		fmt.Printf("Failed to open the browser: %s\nPlease open the URL manually\n\n", err.Error())
 	}
 


### PR DESCRIPTION
## Description

Add no-browser option to login command

Relates to https://feedback.spacelift.io/p/add-a-no-open-option-to-spacectl-profile-login
## Type of Change

- [x] New feature

## Changes Made

- Add no-browser option to login command

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
