### PR TITLE
mcp: define string item schemas for array inputs

### DIFF
--- a/internal/cmd/context/mcp.go
+++ b/internal/cmd/context/mcp.go
@@ -210,7 +210,7 @@ func registerSearchContextsTool(s *server.MCPServer) {
 		}),
 		mcp.WithString("search", mcp.Description("Full text search query")),
 		mcp.WithString("space", mcp.Description("Filter by space ID")),
-		mcp.WithArray("labels", mcp.Description("Filter by labels (array of strings)")),
+		mcp.WithArray("labels", mcp.Description("Filter by labels (array of strings)"), mcp.WithStringItems()),
 		mcp.WithNumber("limit", mcp.Description("The maximum number of contexts to return, default is 50")),
 		mcp.WithString("next_page_cursor", mcp.Description("The pagination cursor to use for fetching the next page of results")),
 	)

--- a/internal/cmd/module/mcp.go
+++ b/internal/cmd/module/mcp.go
@@ -378,7 +378,7 @@ func registerSearchModulesTool(s *server.MCPServer) {
 		mcp.WithString("search", mcp.Description("Full text search query")),
 		mcp.WithString("terraform_provider", mcp.Description("Filter by Terraform provider (e.g., 'aws', 'gcp', 'azure')")),
 		mcp.WithString("space", mcp.Description("Filter by space ID")),
-		mcp.WithArray("labels", mcp.Description("Filter by labels (array of strings)")),
+		mcp.WithArray("labels", mcp.Description("Filter by labels (array of strings)"), mcp.WithStringItems()),
 		mcp.WithBoolean("public_only", mcp.Description("Only return public modules (default: false)")),
 		mcp.WithNumber("limit", mcp.Description("The maximum number of modules to return, default is 50")),
 		mcp.WithString("next_page_cursor", mcp.Description("The pagination cursor to use for fetching the next page of results")),

--- a/internal/cmd/stack/mcp.go
+++ b/internal/cmd/stack/mcp.go
@@ -585,7 +585,11 @@ func registerLocalPreviewTool(s *server.MCPServer, options McpOptions) {
 		}),
 		mcp.WithString("stack_id", mcp.Description("The ID of the stack"), mcp.Required()),
 		mcp.WithObject("environment_variables", mcp.Description("Environment variables to set for the run")),
-		mcp.WithArray("targets", mcp.Description("Limit the planning operation to only the given module, resource, or resource instance and all of its dependencies.")),
+		mcp.WithArray(
+			"targets",
+			mcp.Description("Limit the planning operation to only the given module, resource, or resource instance and all of its dependencies."),
+			mcp.WithStringItems(),
+		),
 		mcp.WithString("path", mcp.Description("The path to the local workspace. If not provided, the current working directory will be used.")),
 		mcp.WithString(
 			"await_for_completion",


### PR DESCRIPTION
## Description

MCP tools were declaring several inputs as arrays but not specifying the type of items those arrays contain. This left the generated JSON Schema ambiguous for clients and validators, even though the tool descriptions expected string arrays.

Add string item schemas for label filters on context/module search and targets on local preview so MCP clients can correctly validate and construct calls for these parameters.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- List the main changes
- Include any important details
- Mention files or components affected

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Screenshots (if applicable)

Add screenshots to show visual changes.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings

## Related Issues

Fixes #402