### PR TITLE
add space details to stack show command

### DIFF
--- a/internal/cmd/stack/show.go
+++ b/internal/cmd/stack/show.go
@@ -227,6 +227,12 @@ type showStackQuery[VC stackVendorConfig] struct {
 		Provider               string   `graphql:"provider" json:"provider,omitempty"`
 		Repository             string   `graphql:"repository" json:"repository,omitempty"`
 		RunnerImage            string   `graphql:"runnerImage" json:"runnerImage,omitempty"`
+		SpaceDetails 	       struct {
+			ID          string  `graphql:"id" json:"id,omitempty"`
+			Name        string  `graphql:"name" json:"name,omitempty"`
+			Description string  `graphql:"description" json:"description,omitempty"`
+			ParentSpace *string `graphql:"parentSpace" json:"parentSpace,omitempty"`
+		} `graphql:"spaceDetails" json:"spaceDetails"`
 		Starred                bool     `graphql:"starred" json:"starred"`
 		State                  string   `graphql:"state" json:"state,omitempty"`
 		StateSetAt             int64    `graphql:"stateSetAt" json:"stateSetAt,omitempty"`
@@ -310,6 +316,9 @@ func (c *showStackCommand[VC]) showStackTable(query showStackQuery[VC]) error {
 
 func (c *showStackCommand[VC]) outputStackNameSection(query showStackQuery[VC]) {
 	pterm.DefaultSection.WithLevel(1).Print(query.Stack.Name)
+
+	pterm.DefaultSection.WithLevel(2).Println("Space")
+	pterm.DefaultParagraph.Println(fmt.Sprintf("%s (%s)", query.Stack.SpaceDetails.Name, query.Stack.SpaceDetails.ID))
 
 	if len(query.Stack.Labels) > 0 {
 		pterm.DefaultSection.WithLevel(2).Println("Labels")


### PR DESCRIPTION
## Description

Added space details output when running stack show command.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

I updated show.go to just list space information when running stack show and stack show -o json

## Testing

- [X] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All existing tests pass

## Screenshots (if applicable)

Add screenshots to show visual changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Related Issues

Closes #(issue number)
Fixes #(issue number)
Related to #(issue number)
