### PR TITLE
feat(profile): export-token works from environment credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,46 @@ steps:
     run: spacectl stack deploy --id my-infra-stack
 ```
 
+<details>
+<summary><strong>Authenticating with GitHub OIDC instead</strong> (no long-lived secret)</summary>
+
+<br>
+
+Instead of storing a long-lived secret, let GitHub mint a short-lived OIDC token and exchange it for a Spacelift session token. This needs an [API key configured for OIDC](https://docs.spacelift.io/integrations/api#spacelift-api-key-via-oidc) and `id-token: write` permission on the job.
+
+The OIDC token GitHub issues is short-lived (~5 minutes), so exchange it **once** for a Spacelift session token (valid up to ~10 hours) and reuse that for the rest of the job. `spacectl profile export-token` does the exchange for you, picking up the OIDC token straight from the environment so you don't have to hand-roll the `apiKeyUser` GraphQL mutation:
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Install spacectl
+        uses: spacelift-io/setup-spacectl@main
+
+      - name: Authenticate to Spacelift
+        env:
+          SPACELIFT_API_KEY_ENDPOINT: https://mycorp.app.spacelift.io
+          SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_API_KEY_ID }}
+        run: |
+          set -euo pipefail
+          # Mint the GitHub OIDC token and hand it to spacectl as the key secret.
+          export SPACELIFT_API_KEY_SECRET=$(curl -sH "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=mycorp.app.spacelift.io" | jq -r '.value')
+          # Exchange it once for a longer-lived session token and reuse it everywhere.
+          JWT=$(spacectl profile export-token)
+          echo "::add-mask::$JWT"
+          echo "SPACELIFT_API_TOKEN=${JWT}" >> "$GITHUB_ENV"
+
+      - name: Deploy infrastructure
+        run: spacectl stack deploy --id my-infra-stack
+```
+
+</details>
+
 ---
 
 ### Community supported packages

--- a/internal/cmd/profile/export_token.go
+++ b/internal/cmd/profile/export_token.go
@@ -2,12 +2,13 @@ package profile
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/spacelift-io/spacectl/internal/cmd"
 )
 
@@ -18,17 +19,12 @@ func exportTokenCommand() *cli.Command {
 			"we suggest piping it to your OS pastebin",
 		ArgsUsage: cmd.EmptyArgsUsage,
 		Action: func(ctx context.Context, _ *cli.Command) error {
-			currentProfile := manager.Current()
-			if currentProfile == nil {
-				return errors.New("no account is currently selected")
-			}
-
-			session, err := currentProfile.Credentials.Session(ctx, http.DefaultClient)
+			sess, err := resolveSession(ctx, manager, http.DefaultClient, os.LookupEnv)
 			if err != nil {
 				return fmt.Errorf("could not get session: %w", err)
 			}
 
-			token, err := session.BearerToken(ctx)
+			token, err := sess.BearerToken(ctx)
 			if err != nil {
 				return fmt.Errorf("could not get bearer token: %w", err)
 			}
@@ -40,4 +36,20 @@ func exportTokenCommand() *cli.Command {
 			return nil
 		},
 	}
+}
+
+// resolveSession returns the session to export a token from. It prefers the
+// currently selected profile, falling back to credentials from the environment
+// when none is set (e.g. in CI, where SPACELIFT_API_KEY_ID and
+// SPACELIFT_API_KEY_SECRET - the latter possibly an OIDC token - are provided
+// directly). The fallback lets `export-token` exchange those for a session token
+// without anyone having to hand-roll the apiKeyUser GraphQL mutation.
+func resolveSession(ctx context.Context, m *session.ProfileManager, httpClient *http.Client, lookup func(string) (string, bool)) (session.Session, error) {
+	if m != nil {
+		if current := m.Current(); current != nil {
+			return current.Credentials.Session(ctx, httpClient)
+		}
+	}
+
+	return session.FromEnvironment(ctx, httpClient)(lookup)
 }

--- a/internal/cmd/profile/export_token_test.go
+++ b/internal/cmd/profile/export_token_test.go
@@ -1,0 +1,127 @@
+package profile
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+
+	"github.com/spacelift-io/spacectl/client/session"
+)
+
+// sampleAPIToken is a JWT with header {"alg":"HS256","typ":"JWT"} and payload
+// {"aud":"spacectl","exp":1516239022}, generated at https://jwt.io. It only
+// needs to carry a single audience claim to be parseable by FromAPIToken.
+const sampleAPIToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJzcGFjZWN0bCIsImV4cCI6MTUxNjIzOTAyMn0.fsKd_N2TKXpx83JSPPw47zYzQ8sbSzGVPZcyGpwp05U" //nolint:gosec // sample JWT for tests, not a real credential
+
+// envLookup builds an os.LookupEnv-style func from a map.
+func envLookup(values map[string]string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		v, ok := values[key]
+		return v, ok
+	}
+}
+
+func TestResolveSession(t *testing.T) {
+	t.Run("falls back to the environment when no profile manager is set", func(t *testing.T) {
+		server := newExchangeServer(t, "EnvJWT")
+		defer server.Close()
+
+		lookup := envLookup(map[string]string{
+			session.EnvSpaceliftAPIKeyEndpoint: server.URL,
+			session.EnvSpaceliftAPIKeyID:       "key-id",
+			session.EnvSpaceliftAPIKeySecret:   "oidc-token",
+		})
+
+		sess, err := resolveSession(context.Background(), nil, server.Client(), lookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertBearerToken(t, sess, "EnvJWT")
+	})
+
+	t.Run("falls back to the environment when no profile is selected", func(t *testing.T) {
+		server := newExchangeServer(t, "EnvJWT")
+		defer server.Close()
+
+		// A manager pointing at an empty directory has no current profile,
+		// mirroring a CI run that authenticates purely through the environment.
+		manager, err := session.NewProfileManager(path.Join(t.TempDir(), "profiles"))
+		if err != nil {
+			t.Fatalf("could not create profile manager: %v", err)
+		}
+
+		lookup := envLookup(map[string]string{
+			session.EnvSpaceliftAPIKeyEndpoint: server.URL,
+			session.EnvSpaceliftAPIKeyID:       "key-id",
+			session.EnvSpaceliftAPIKeySecret:   "oidc-token",
+		})
+
+		sess, err := resolveSession(context.Background(), manager, server.Client(), lookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertBearerToken(t, sess, "EnvJWT")
+	})
+
+	t.Run("prefers the selected profile over the environment", func(t *testing.T) {
+		manager, err := session.NewProfileManager(path.Join(t.TempDir(), "profiles"))
+		if err != nil {
+			t.Fatalf("could not create profile manager: %v", err)
+		}
+
+		if err := manager.Create(&session.Profile{
+			Alias: "default",
+			Credentials: &session.StoredCredentials{
+				Type:        session.CredentialsTypeAPIToken,
+				Endpoint:    "https://spacectl.app.spacelift.io",
+				AccessToken: sampleAPIToken,
+			},
+		}); err != nil {
+			t.Fatalf("could not create profile: %v", err)
+		}
+
+		// Environment points somewhere that would explode if it were used,
+		// proving the profile takes precedence.
+		lookup := envLookup(map[string]string{
+			session.EnvSpaceliftAPIKeyEndpoint: "http://127.0.0.1:0",
+			session.EnvSpaceliftAPIKeyID:       "key-id",
+			session.EnvSpaceliftAPIKeySecret:   "oidc-token",
+		})
+
+		sess, err := resolveSession(context.Background(), manager, http.DefaultClient, lookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertBearerToken(t, sess, sampleAPIToken)
+	})
+}
+
+// newExchangeServer returns a mock GraphQL server that answers the apiKeyUser
+// mutation with the given JWT.
+func newExchangeServer(t *testing.T, jwt string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		if _, err := rw.Write([]byte(`{"data":{"apiKeyUser":{"jwt":"` + jwt + `","validUntil":4102444800}}}`)); err != nil {
+			t.Errorf("could not write mock response: %v", err)
+		}
+	}))
+}
+
+func assertBearerToken(t *testing.T, sess session.Session, want string) {
+	t.Helper()
+	if sess == nil {
+		t.Fatal("expected a session, got nil")
+	}
+	token, err := sess.BearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("could not get bearer token: %v", err)
+	}
+	if token != want {
+		t.Fatalf("unexpected bearer token: got %q, want %q", token, want)
+	}
+}


### PR DESCRIPTION
## What

`spacectl profile export-token` only resolved a token from the currently selected profile (`manager.Current()`), so it was unusable in CI - where there is no profile and auth comes from environment variables (`SPACELIFT_API_KEY_ID` + `SPACELIFT_API_KEY_SECRET`, the latter frequently a short-lived GitHub OIDC token).

This makes `export-token` fall back to `session.FromEnvironment` when no profile is selected. A selected profile still takes precedence, so existing behavior is unchanged.

## Why

The GitHub OIDC token used in CI lives only ~5 minutes. For anything longer than a quick command you have to exchange it once for a Spacelift session token (~10h) and reuse that as `SPACELIFT_API_TOKEN`. Until now the only way to get that token out of the env-based flow was to hand-write the `apiKeyUser` GraphQL mutation with `curl`. With this change CI collapses to:

```bash
# mint the GitHub OIDC token (GitHub's, unavoidable) into SPACELIFT_API_KEY_SECRET, then:
echo "SPACELIFT_API_TOKEN=$(spacectl profile export-token)" >> "$GITHUB_ENV"
```

Closes [CU-869dwdkyq](https://app.clickup.com/t/869dwdkyq).