### PR TITLE
Add the logs command for modules

### DIFF
--- a/internal/cmd/module/flags.go
+++ b/internal/cmd/module/flags.go
@@ -24,6 +24,23 @@ var flagCommitSHA = &cli.StringFlag{
 	Usage: "Commit `SHA` to use for the module version",
 }
 
+var flagRun = &cli.StringFlag{
+	Name:     "run",
+	Usage:    "[Required] `ID` of the run",
+	Required: true,
+}
+
+var flagPhase = &cli.StringFlag{
+	Name:  "phase",
+	Usage: "[Optional] Only show logs for a specific `PHASE` (e.g., QUEUED, PREPARING, PLANNING, APPLYING, FINISHED)",
+}
+
+var flagTail = &cli.BoolFlag{
+	Name:  "tail",
+	Usage: "Indicate whether to tail the run",
+	Value: false,
+}
+
 var flagNoFindRepositoryRoot = &cli.BoolFlag{
 	Name:  "no-find-repository-root",
 	Usage: "Indicate whether spacectl should avoid finding the repository root (containing a .git directory) before packaging it.",

--- a/internal/cmd/module/logs.go
+++ b/internal/cmd/module/logs.go
@@ -1,0 +1,30 @@
+package module
+
+import (
+	"context"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/spacelift-io/spacectl/client/structs"
+	"github.com/spacelift-io/spacectl/internal/logs"
+)
+
+func moduleLogs(ctx context.Context, cliCmd *cli.Command) error {
+	moduleID := cliCmd.String(flagModuleID.Name)
+	runID := cliCmd.String(flagRun.Name)
+
+	var targetPhase *structs.RunState
+	if cliCmd.IsSet(flagPhase.Name) {
+		phase := structs.RunState(strings.ToUpper(cliCmd.String(flagPhase.Name)))
+		targetPhase = &phase
+	}
+
+	_, err := logs.NewExplorer(moduleID, runID,
+		logs.WithModule(),
+		logs.WithTail(cliCmd.Bool(flagTail.Name)),
+		logs.WithTargetPhase(targetPhase),
+	).RunFilteredLogs(ctx)
+
+	return err
+}

--- a/internal/cmd/module/logs.go
+++ b/internal/cmd/module/logs.go
@@ -20,8 +20,7 @@ func moduleLogs(ctx context.Context, cliCmd *cli.Command) error {
 		targetPhase = &phase
 	}
 
-	_, err := logs.NewExplorer(moduleID, runID,
-		logs.WithModule(),
+	_, err := logs.NewModuleExplorer(moduleID, runID,
 		logs.WithTail(cliCmd.Bool(flagTail.Name)),
 		logs.WithTargetPhase(targetPhase),
 	).RunFilteredLogs(ctx)

--- a/internal/cmd/module/module.go
+++ b/internal/cmd/module/module.go
@@ -101,6 +101,27 @@ func Command() cmd.Command {
 				},
 			},
 			{
+				Category: "Run management",
+				Name:     "logs",
+				Usage:    "Show logs for a particular module run",
+				Versions: []cmd.VersionedCommand{
+					{
+						EarliestVersion: cmd.SupportedVersionAll,
+						Command: &cli.Command{
+							Flags: []cli.Flag{
+								flagModuleID,
+								flagRun,
+								flagPhase,
+								flagTail,
+							},
+							Action:    moduleLogs,
+							Before:    authenticated.Ensure,
+							ArgsUsage: cmd.EmptyArgsUsage,
+						},
+					},
+				},
+			},
+			{
 				Category: "Module management",
 				Name:     "list",
 				Usage:    "List all modules available and their current version",

--- a/internal/cmd/stack/local_preview.go
+++ b/internal/cmd/stack/local_preview.go
@@ -102,7 +102,7 @@ func localPreview(useHeaders bool) cli.ActionFunc {
 			return nil
 		}
 
-		terminal, err := logs.NewExplorer(s.ID, runID).RunFilteredLogs(ctx)
+		terminal, err := logs.NewStackExplorer(s.ID, runID).RunFilteredLogs(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/mcp.go
+++ b/internal/cmd/stack/mcp.go
@@ -313,7 +313,7 @@ func registerGetStackRunLogsTool(s *server.MCPServer) {
 			}
 		}()
 
-		terminal, err = logs.NewExplorer(stackID, runID).RunFilteredStates(ctx, logLines)
+		terminal, err = logs.NewStackExplorer(stackID, runID).RunFilteredStates(ctx, logLines)
 		close(logLines)
 
 		if err != nil {
@@ -700,7 +700,7 @@ func registerLocalPreviewTool(s *server.MCPServer, options McpOptions) {
 			}
 		}()
 
-		terminal, err := logs.NewExplorer(stackID, runID).RunFilteredStates(ctx, logLines)
+		terminal, err := logs.NewStackExplorer(stackID, runID).RunFilteredStates(ctx, logLines)
 		close(logLines)
 
 		if err != nil {

--- a/internal/cmd/stack/run_cancel.go
+++ b/internal/cmd/stack/run_cancel.go
@@ -45,7 +45,7 @@ func runCancel() cli.ActionFunc {
 			return nil
 		}
 
-		terminal, err := logs.NewExplorer(stackID, mutation.RunDiscard.ID).RunFilteredLogs(ctx)
+		terminal, err := logs.NewStackExplorer(stackID, mutation.RunDiscard.ID).RunFilteredLogs(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_confirm.go
+++ b/internal/cmd/stack/run_confirm.go
@@ -51,7 +51,7 @@ func runConfirm() cli.ActionFunc {
 			return nil
 		}
 
-		terminal, err := logs.NewExplorer(stackID, mutation.RunConfirm.ID).RunFilteredLogs(ctx)
+		terminal, err := logs.NewStackExplorer(stackID, mutation.RunConfirm.ID).RunFilteredLogs(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_deprioritize.go
+++ b/internal/cmd/stack/run_deprioritize.go
@@ -33,7 +33,7 @@ func runDeprioritize(ctx context.Context, cliCmd *cli.Command) error {
 		return nil
 	}
 
-	terminal, err := logs.NewExplorer(stackID, mutation.SetRunPriority.ID).RunFilteredLogs(ctx)
+	terminal, err := logs.NewStackExplorer(stackID, mutation.SetRunPriority.ID).RunFilteredLogs(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_discard.go
+++ b/internal/cmd/stack/run_discard.go
@@ -45,7 +45,7 @@ func runDiscard() cli.ActionFunc {
 			return nil
 		}
 
-		terminal, err := logs.NewExplorer(stackID, mutation.RunDiscard.ID).RunFilteredLogs(ctx)
+		terminal, err := logs.NewStackExplorer(stackID, mutation.RunDiscard.ID).RunFilteredLogs(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_logs.go
+++ b/internal/cmd/stack/run_logs.go
@@ -66,7 +66,7 @@ func runLogs(ctx context.Context, cliCmd *cli.Command) error {
 		targetPhase = &phase
 	}
 
-	_, err = logs.NewExplorer(stackID, runID,
+	_, err = logs.NewStackExplorer(stackID, runID,
 		logs.WithTail(cliCmd.Bool(flagTail.Name)),
 		logs.WithTargetPhase(targetPhase),
 	).RunFilteredLogs(ctx)

--- a/internal/cmd/stack/run_prioritize.go
+++ b/internal/cmd/stack/run_prioritize.go
@@ -34,7 +34,7 @@ func runPrioritize(ctx context.Context, cliCmd *cli.Command) error {
 		return nil
 	}
 
-	terminal, err := logs.NewExplorer(stackID, mutation.SetRunPriority.ID).RunFilteredLogs(ctx)
+	terminal, err := logs.NewStackExplorer(stackID, mutation.SetRunPriority.ID).RunFilteredLogs(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_promote.go
+++ b/internal/cmd/stack/run_promote.go
@@ -45,7 +45,7 @@ func runPromote() cli.ActionFunc {
 			return nil
 		}
 
-		terminal, err := logs.NewExplorer(stackID, mutation.RunPromote.ID).RunFilteredLogs(ctx)
+		terminal, err := logs.NewStackExplorer(stackID, mutation.RunPromote.ID).RunFilteredLogs(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_replan.go
+++ b/internal/cmd/stack/run_replan.go
@@ -70,7 +70,7 @@ func runReplan(ctx context.Context, cliCmd *cli.Command) error {
 		return nil
 	}
 
-	terminal, err := logs.NewExplorer(stackID, mutation.RunTargetedReplan.ID).RunFilteredLogs(ctx)
+	terminal, err := logs.NewStackExplorer(stackID, mutation.RunTargetedReplan.ID).RunFilteredLogs(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_retry.go
+++ b/internal/cmd/stack/run_retry.go
@@ -44,7 +44,7 @@ func runRetry(ctx context.Context, cliCmd *cli.Command) error {
 		return nil
 	}
 
-	terminal, err := logs.NewExplorer(stackID, mutation.RunRetry.ID).RunFilteredLogs(ctx)
+	terminal, err := logs.NewStackExplorer(stackID, mutation.RunRetry.ID).RunFilteredLogs(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/run_stop.go
+++ b/internal/cmd/stack/run_stop.go
@@ -46,7 +46,7 @@ func runStop() cli.ActionFunc {
 			return nil
 		}
 
-		terminal, err := logs.NewExplorer(stackID, mutation.RunStop.ID).RunFilteredLogs(ctx)
+		terminal, err := logs.NewStackExplorer(stackID, mutation.RunStop.ID).RunFilteredLogs(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/stack/run_trigger.go
+++ b/internal/cmd/stack/run_trigger.go
@@ -161,7 +161,7 @@ func finalizeRunTrigger(ctx context.Context, cliCmd *cli.Command, stackID, runID
 		return nil
 	}
 
-	terminal, err := logs.NewExplorer(stackID, runID, logs.WithActionOnRunState(actionFn)).RunFilteredLogs(ctx)
+	terminal, err := logs.NewStackExplorer(stackID, runID, logs.WithActionOnRunState(actionFn)).RunFilteredLogs(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stack/task_command.go
+++ b/internal/cmd/stack/task_command.go
@@ -52,7 +52,7 @@ func taskCommand(ctx context.Context, cliCmd *cli.Command) error {
 		return nil
 	}
 
-	terminal, err := logs.NewExplorer(stackID, mutation.TaskCreate.ID).RunFilteredLogs(ctx)
+	terminal, err := logs.NewStackExplorer(stackID, mutation.TaskCreate.ID).RunFilteredLogs(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/logs/explorer.go
+++ b/internal/logs/explorer.go
@@ -29,14 +29,24 @@ type Explorer struct {
 	backoff time.Duration
 }
 
-// NewExplorer creates a new Explorer with the given options.
-// By default the explorer explores a stack's run and always tails the logs;
-// use WithModule to explore a module's run instead.
-func NewExplorer(id, run string, opts ...Option) *Explorer {
+// NewStackExplorer creates a new Explorer for a run belonging to a stack.
+// By default the explorer always tails the logs.
+func NewStackExplorer(stackID, run string, opts ...Option) *Explorer {
+	return newExplorer(entityStack, stackID, run, opts...)
+}
+
+// NewModuleExplorer creates a new Explorer for a run belonging to a module.
+// By default the explorer always tails the logs.
+func NewModuleExplorer(moduleID, run string, opts ...Option) *Explorer {
+	return newExplorer(entityModule, moduleID, run, opts...)
+}
+
+func newExplorer(entity entity, id, run string, opts ...Option) *Explorer {
 	e := &Explorer{
 		id:      id,
 		run:     run,
 		tail:    true,
+		entity:  entity,
 		backoff: 0,
 	}
 

--- a/internal/logs/explorer.go
+++ b/internal/logs/explorer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shurcooL/graphql"
 
 	"github.com/spacelift-io/spacectl/client/structs"
+	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
 // Explorer allows you to explore run logs, either for a stack or a module.
@@ -101,12 +102,47 @@ func (e *Explorer) getHistory(ctx context.Context) ([]structs.RunStateTransition
 		"run": graphql.ID(e.run),
 	}
 
-	run, err := queryRun[runHistory](ctx, e, variables)
-	if err != nil {
+	if e.entity == entityModule {
+		var query struct {
+			Module *struct {
+				Run *runHistory `graphql:"run(id: $run)"`
+			} `graphql:"module(id: $id)"`
+		}
+
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+			return nil, err
+		}
+
+		if query.Module == nil {
+			return nil, fmt.Errorf("%s %q not found", e.entity, e.id)
+		}
+
+		if query.Module.Run == nil {
+			return nil, fmt.Errorf("run %q in %s %q not found", e.run, e.entity, e.id)
+		}
+
+		return query.Module.Run.History, nil
+	}
+
+	var query struct {
+		Stack *struct {
+			Run *runHistory `graphql:"run(id: $run)"`
+		} `graphql:"stack(id: $id)"`
+	}
+
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
 		return nil, err
 	}
 
-	return run.History, nil
+	if query.Stack == nil {
+		return nil, fmt.Errorf("%s %q not found", e.entity, e.id)
+	}
+
+	if query.Stack.Run == nil {
+		return nil, fmt.Errorf("run %q in %s %q not found", e.run, e.entity, e.id)
+	}
+
+	return query.Stack.Run.History, nil
 }
 
 func (e *Explorer) processHistory(ctx context.Context, sink chan<- string, history []structs.RunStateTransition, reportedStates map[structs.RunState]struct{}) (*structs.RunStateTransition, bool, error) {
@@ -207,13 +243,4 @@ func (e *Explorer) actionFunc(state structs.RunState) error {
 	}
 
 	return nil
-}
-
-// label returns a human-readable name for the entity whose run is being explored.
-func (e *Explorer) label() string {
-	if e.entity == entityModule {
-		return "module"
-	}
-
-	return "stack"
 }

--- a/internal/logs/explorer.go
+++ b/internal/logs/explorer.go
@@ -10,16 +10,16 @@ import (
 	"github.com/shurcooL/graphql"
 
 	"github.com/spacelift-io/spacectl/client/structs"
-	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
-// Explorer allows you to explore stack run logs.
+// Explorer allows you to explore run logs, either for a stack or a module.
 //
 // It's a single use object, which should be thrown away after use.
 type Explorer struct {
-	stack string
-	run   string
-	tail  bool
+	id     string
+	run    string
+	tail   bool
+	entity entity
 
 	acFn               ActionOnRunState
 	targetPhase        *structs.RunState
@@ -29,10 +29,11 @@ type Explorer struct {
 }
 
 // NewExplorer creates a new Explorer with the given options.
-// By default the explorer always tails the logs.
-func NewExplorer(stack, run string, opts ...Option) *Explorer {
+// By default the explorer explores a stack's run and always tails the logs;
+// use WithModule to explore a module's run instead.
+func NewExplorer(id, run string, opts ...Option) *Explorer {
 	e := &Explorer{
-		stack:   stack,
+		id:      id,
 		run:     run,
 		tail:    true,
 		backoff: 0,
@@ -91,32 +92,21 @@ func (e *Explorer) RunFilteredStates(ctx context.Context, sink chan<- string) (*
 }
 
 func (e *Explorer) getHistory(ctx context.Context) ([]structs.RunStateTransition, error) {
-	var query struct {
-		Stack *struct {
-			Run *struct {
-				History []structs.RunStateTransition `graphql:"history"`
-			} `graphql:"run(id: $run)"`
-		} `graphql:"stack(id: $stack)"`
+	type runHistory struct {
+		History []structs.RunStateTransition `graphql:"history"`
 	}
 
 	variables := map[string]any{
-		"stack": graphql.ID(e.stack),
-		"run":   graphql.ID(e.run),
+		"id":  graphql.ID(e.id),
+		"run": graphql.ID(e.run),
 	}
 
-	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+	run, err := queryRun[runHistory](ctx, e, variables)
+	if err != nil {
 		return nil, err
 	}
 
-	if query.Stack == nil {
-		return nil, fmt.Errorf("stack %q not found", e.stack)
-	}
-
-	if query.Stack.Run == nil {
-		return nil, fmt.Errorf("run %q in stack %q not found", e.run, e.stack)
-	}
-
-	return query.Stack.Run.History, nil
+	return run.History, nil
 }
 
 func (e *Explorer) processHistory(ctx context.Context, sink chan<- string, history []structs.RunStateTransition, reportedStates map[structs.RunState]struct{}) (*structs.RunStateTransition, bool, error) {
@@ -181,7 +171,7 @@ func (e *Explorer) processTargetPhase(transition *structs.RunStateTransition, si
 
 func (e *Explorer) processTransition(ctx context.Context, transition *structs.RunStateTransition, sink chan<- string) (bool, error) {
 	if transition.HasLogs {
-		if err := runStateLogs(ctx, e.stack, e.run, transition.State, transition.StateVersion, sink, transition.Terminal); err != nil {
+		if err := e.runStateLogs(ctx, transition.State, transition.StateVersion, sink, transition.Terminal); err != nil {
 			return false, err
 		}
 	}
@@ -212,9 +202,18 @@ func (e *Explorer) actionFunc(state structs.RunState) error {
 		return nil
 	}
 
-	if err := e.acFn(state, e.stack, e.run); err != nil {
+	if err := e.acFn(state, e.id, e.run); err != nil {
 		return fmt.Errorf("failed to execute action on run state: %w", err)
 	}
 
 	return nil
+}
+
+// label returns a human-readable name for the entity whose run is being explored.
+func (e *Explorer) label() string {
+	if e.entity == entityModule {
+		return "module"
+	}
+
+	return "stack"
 }

--- a/internal/logs/explorer_test.go
+++ b/internal/logs/explorer_test.go
@@ -93,7 +93,7 @@ func TestProcessTargetPhase(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			explorer := &Explorer{
-				stack:              "test-stack",
+				id:                 "test-stack",
 				run:                "test-run",
 				targetPhase:        tc.targetPhase,
 				targetPhaseReached: tc.targetPhaseReached,
@@ -174,7 +174,7 @@ func TestProcessTargetPhaseTerminalFlag(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			explorer := &Explorer{
-				stack:              "test-stack",
+				id:                 "test-stack",
 				run:                "test-run",
 				targetPhase:        &targetState,
 				targetPhaseReached: true, // Target already reached

--- a/internal/logs/option.go
+++ b/internal/logs/option.go
@@ -13,6 +13,15 @@ const (
 	entityModule
 )
 
+// String returns a human-readable name for the entity whose run is being explored.
+func (e entity) String() string {
+	if e == entityModule {
+		return "module"
+	}
+
+	return "stack"
+}
+
 type ActionOnRunState func(state structs.RunState, stackID, runID string) error
 
 // WithModule indicates that the explored run belongs to a module rather than a stack.

--- a/internal/logs/option.go
+++ b/internal/logs/option.go
@@ -24,13 +24,6 @@ func (e entity) String() string {
 
 type ActionOnRunState func(state structs.RunState, stackID, runID string) error
 
-// WithModule indicates that the explored run belongs to a module rather than a stack.
-func WithModule() Option {
-	return func(e *Explorer) {
-		e.entity = entityModule
-	}
-}
-
 // WithActionOnRunState sets an action to be executed on each run state
 func WithActionOnRunState(acFn ActionOnRunState) Option {
 	return func(e *Explorer) {

--- a/internal/logs/option.go
+++ b/internal/logs/option.go
@@ -5,7 +5,22 @@ import "github.com/spacelift-io/spacectl/client/structs"
 // Option is a functional option for configuring an Explorer
 type Option func(*Explorer)
 
+// entity identifies the parent type whose run logs are being explored.
+type entity int
+
+const (
+	entityStack entity = iota
+	entityModule
+)
+
 type ActionOnRunState func(state structs.RunState, stackID, runID string) error
+
+// WithModule indicates that the explored run belongs to a module rather than a stack.
+func WithModule() Option {
+	return func(e *Explorer) {
+		e.entity = entityModule
+	}
+}
 
 // WithActionOnRunState sets an action to be executed on each run state
 func WithActionOnRunState(acFn ActionOnRunState) Option {

--- a/internal/logs/query.go
+++ b/internal/logs/query.go
@@ -21,55 +21,7 @@ type logsQuery struct {
 	NextToken *graphql.String `graphql:"nextToken"`
 }
 
-func queryRun[T any](ctx context.Context, e *Explorer, variables map[string]any) (*T, error) {
-	var run *T
-
-	if e.entity == entityModule {
-		var query struct {
-			Module *struct {
-				Run *T `graphql:"run(id: $run)"`
-			} `graphql:"module(id: $id)"`
-		}
-
-		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
-			return nil, err
-		}
-
-		if query.Module == nil {
-			return nil, fmt.Errorf("%s %q not found", e.label(), e.id)
-		}
-
-		run = query.Module.Run
-	} else {
-		var query struct {
-			Stack *struct {
-				Run *T `graphql:"run(id: $run)"`
-			} `graphql:"stack(id: $id)"`
-		}
-
-		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
-			return nil, err
-		}
-
-		if query.Stack == nil {
-			return nil, fmt.Errorf("%s %q not found", e.label(), e.id)
-		}
-
-		run = query.Stack.Run
-	}
-
-	if run == nil {
-		return nil, fmt.Errorf("run %q in %s %q not found", e.run, e.label(), e.id)
-	}
-
-	return run, nil
-}
-
 func (e *Explorer) runStateLogs(ctx context.Context, state structs.RunState, version int, sink chan<- string, stateTerminal bool) error {
-	type runLogs struct {
-		Logs *logsQuery `graphql:"logs(state: $state, token: $token, stateVersion: $stateVersion)"`
-	}
-
 	var token *graphql.String
 	variables := map[string]any{
 		"id":           graphql.ID(e.id),
@@ -82,16 +34,11 @@ func (e *Explorer) runStateLogs(ctx context.Context, state structs.RunState, ver
 	var backOff time.Duration
 
 	for {
-		run, err := queryRun[runLogs](ctx, e, variables)
+		logs, err := e.queryStateLogs(ctx, variables)
 		if err != nil {
 			return err
 		}
 
-		if run.Logs == nil {
-			return fmt.Errorf("logs for run %q in %s %q not found", e.run, e.label(), e.id)
-		}
-
-		logs := run.Logs
 		variables["token"] = logs.NextToken
 
 		for _, message := range logs.Messages {
@@ -112,4 +59,60 @@ func (e *Explorer) runStateLogs(ctx context.Context, state structs.RunState, ver
 	}
 
 	return nil
+}
+
+func (e *Explorer) queryStateLogs(ctx context.Context, variables map[string]any) (*logsQuery, error) {
+	type runLogs struct {
+		Logs *logsQuery `graphql:"logs(state: $state, token: $token, stateVersion: $stateVersion)"`
+	}
+
+	if e.entity == entityModule {
+		var query struct {
+			Module *struct {
+				Run *runLogs `graphql:"run(id: $run)"`
+			} `graphql:"module(id: $id)"`
+		}
+
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+			return nil, err
+		}
+
+		if query.Module == nil {
+			return nil, fmt.Errorf("%s %q not found", e.entity, e.id)
+		}
+
+		if query.Module.Run == nil {
+			return nil, fmt.Errorf("run %q in %s %q not found", e.run, e.entity, e.id)
+		}
+
+		if query.Module.Run.Logs == nil {
+			return nil, fmt.Errorf("logs for run %q in %s %q not found", e.run, e.entity, e.id)
+		}
+
+		return query.Module.Run.Logs, nil
+	}
+
+	var query struct {
+		Stack *struct {
+			Run *runLogs `graphql:"run(id: $run)"`
+		} `graphql:"stack(id: $id)"`
+	}
+
+	if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+		return nil, err
+	}
+
+	if query.Stack == nil {
+		return nil, fmt.Errorf("%s %q not found", e.entity, e.id)
+	}
+
+	if query.Stack.Run == nil {
+		return nil, fmt.Errorf("run %q in %s %q not found", e.run, e.entity, e.id)
+	}
+
+	if query.Stack.Run.Logs == nil {
+		return nil, fmt.Errorf("logs for run %q in %s %q not found", e.run, e.entity, e.id)
+	}
+
+	return query.Stack.Run.Logs, nil
 }

--- a/internal/logs/query.go
+++ b/internal/logs/query.go
@@ -11,27 +11,69 @@ import (
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
 
-func runStateLogs(ctx context.Context, stack, run string, state structs.RunState, version int, sink chan<- string, stateTerminal bool) error {
-	var query struct {
-		Stack *struct {
-			Run *struct {
-				Logs *struct {
-					Exists   bool `graphql:"exists"`
-					Finished bool `graphql:"finished"`
-					HasMore  bool `graphql:"hasMore"`
-					Messages []struct {
-						Body string `graphql:"message"`
-					} `graphql:"messages"`
-					NextToken *graphql.String `graphql:"nextToken"`
-				} `graphql:"logs(state: $state, token: $token, stateVersion: $stateVersion)"`
-			} `graphql:"run(id: $run)"`
-		} `graphql:"stack(id: $stack)"`
+type logsQuery struct {
+	Exists   bool `graphql:"exists"`
+	Finished bool `graphql:"finished"`
+	HasMore  bool `graphql:"hasMore"`
+	Messages []struct {
+		Body string `graphql:"message"`
+	} `graphql:"messages"`
+	NextToken *graphql.String `graphql:"nextToken"`
+}
+
+func queryRun[T any](ctx context.Context, e *Explorer, variables map[string]any) (*T, error) {
+	var run *T
+
+	if e.entity == entityModule {
+		var query struct {
+			Module *struct {
+				Run *T `graphql:"run(id: $run)"`
+			} `graphql:"module(id: $id)"`
+		}
+
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+			return nil, err
+		}
+
+		if query.Module == nil {
+			return nil, fmt.Errorf("%s %q not found", e.label(), e.id)
+		}
+
+		run = query.Module.Run
+	} else {
+		var query struct {
+			Stack *struct {
+				Run *T `graphql:"run(id: $run)"`
+			} `graphql:"stack(id: $id)"`
+		}
+
+		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+			return nil, err
+		}
+
+		if query.Stack == nil {
+			return nil, fmt.Errorf("%s %q not found", e.label(), e.id)
+		}
+
+		run = query.Stack.Run
+	}
+
+	if run == nil {
+		return nil, fmt.Errorf("run %q in %s %q not found", e.run, e.label(), e.id)
+	}
+
+	return run, nil
+}
+
+func (e *Explorer) runStateLogs(ctx context.Context, state structs.RunState, version int, sink chan<- string, stateTerminal bool) error {
+	type runLogs struct {
+		Logs *logsQuery `graphql:"logs(state: $state, token: $token, stateVersion: $stateVersion)"`
 	}
 
 	var token *graphql.String
 	variables := map[string]any{
-		"stack":        graphql.ID(stack),
-		"run":          graphql.ID(run),
+		"id":           graphql.ID(e.id),
+		"run":          graphql.ID(e.run),
 		"state":        state,
 		"token":        token,
 		"stateVersion": graphql.Int(version), //nolint: gosec
@@ -40,23 +82,16 @@ func runStateLogs(ctx context.Context, stack, run string, state structs.RunState
 	var backOff time.Duration
 
 	for {
-		if err := authenticated.Client().Query(ctx, &query, variables); err != nil {
+		run, err := queryRun[runLogs](ctx, e, variables)
+		if err != nil {
 			return err
 		}
 
-		if query.Stack == nil {
-			return fmt.Errorf("stack %q not found", stack)
+		if run.Logs == nil {
+			return fmt.Errorf("logs for run %q in %s %q not found", e.run, e.label(), e.id)
 		}
 
-		if query.Stack.Run == nil {
-			return fmt.Errorf("run %q in stack %q not found", run, stack)
-		}
-
-		if query.Stack.Run.Logs == nil {
-			return fmt.Errorf("logs for run %q in stack %q not found", run, stack)
-		}
-
-		logs := query.Stack.Run.Logs
+		logs := run.Logs
 		variables["token"] = logs.NextToken
 
 		for _, message := range logs.Messages {


### PR DESCRIPTION
## Description

```
./spacectl module logs --id terraform-default-module-good --run 01KY9RP8WG9V6N1VNHS1V7DX7M

-----------------
QUEUED	Fri Jul 24 12:53:17 EEST 2026
-----------------


-----------------
READY	Fri Jul 24 12:53:17 EEST 2026
-----------------


-----------------
PREPARING	Fri Jul 24 12:53:22 EEST 2026
-----------------

[Ground Control] This is Ground Control to public worker 01KY9QN50JCM4GMSQPSSJGSV9P, commencing countdown
[Ground Control] No initialization policies attached
[Ground Control] Creating metadata...
[Ground Control] Uploading metadata...
[Ground Control] Metadata is GO
[Ground Control] Creating workspace...
[Ground Control] Encrypting workspace...
[Ground Control] Uploading workspace...
[Ground Control] Workspace is GO
```


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

