### PR TITLE
Fix mangled endpoint

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -101,7 +101,7 @@ func (c *client) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	// prepend request URL with spacelift endpoint
-	endpoint := strings.TrimRight(c.session.Endpoint(), "/graphql")
+	endpoint := strings.TrimSuffix(c.session.Endpoint(), "/graphql")
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse endpoint: %w", err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,86 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacelift-io/spacectl/client/session"
+)
+
+type fakeSession struct {
+	endpoint string
+}
+
+func (f *fakeSession) BearerToken(context.Context) (string, error) {
+	return "test-token", nil
+}
+
+func (f *fakeSession) Endpoint() string {
+	return f.endpoint
+}
+
+func (f *fakeSession) Type() session.CredentialsType {
+	return session.CredentialsTypeAPIToken
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestClientDo_EndpointTrimming(t *testing.T) {
+	tests := []struct {
+		name         string
+		endpoint     string
+		expectScheme string
+		expectHost   string
+	}{
+		{
+			name:         "endpoint with /graphql suffix",
+			endpoint:     "https://unit.app.spacelift.io/graphql",
+			expectScheme: "https",
+			expectHost:   "unit.app.spacelift.io",
+		},
+		{
+			// Regression test: strings.TrimRight previously trimmed any
+			// trailing characters found in the "/graphql" cutset, which
+			// mangled hosts that don't end in the literal "/graphql"
+			// suffix but happen to end in letters from that set (e.g.
+			// the trailing "rg" in "org").
+			name:         "endpoint without /graphql suffix is left untouched",
+			endpoint:     "https://spacelift.example.org",
+			expectScheme: "https",
+			expectHost:   "spacelift.example.org",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured *http.Request
+
+			wraps := &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					captured = req
+					return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+				}),
+			}
+
+			c := New(wraps, &fakeSession{endpoint: tt.endpoint})
+
+			req, err := http.NewRequest(http.MethodGet, "http://placeholder.invalid/some/path", nil)
+			require.NoError(t, err)
+
+			resp, err := c.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.NotNil(t, captured)
+			assert.Equal(t, tt.expectScheme, captured.URL.Scheme)
+			assert.Equal(t, tt.expectHost, captured.URL.Host)
+			assert.Equal(t, "/some/path", captured.URL.Path)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Some commands were failing with DNS resolution errors:

```
spacectl api --schema     
2026/07/27 16:11:33 error executing request: Post "https://spacelift.foobar.o/graphql": dial tcp: lookup spacelift.foobar.o: no such host
```

The problem is that `strings.TrimRight` trims any trailing characters found in the `/graphql` cutset, which mangled hosts that end with characters in the `/graphql` set (such as `.org`, `.ph`, etc).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- Replaced `strings.TrimRight` with `strings.TrimSuffix` as recommended by Go's documentation.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed
- [ ] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
