### PR TITLE
feat: allow selecting a profile via SPACELIFT_PROFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,19 @@ By default the login process is interactive, however, if that does not fit your 
 
 You can switch between account profiles by using `spacectl profile select ${MY_ALIAS}`. What this does behind the scenes is point `${HOME}/.spacelift/current` to the new location. You can also delete stored credetials for a given profile by using the `spacectl profile logout ${MY_ALIAS}` command.
 
+#### Selecting a profile per command or shell
+
+`spacectl profile select` changes the profile for every shell, since the selection is stored in the config file. When you need one terminal on a different profile - a different organization, or a different API key within the same organization - set the `SPACELIFT_PROFILE` environment variable instead:
+
+```bash
+export SPACELIFT_PROFILE=my-other-account   # for the rest of this shell
+SPACELIFT_PROFILE=my-other-account spacectl stack list   # for a single command
+```
+
+The variable selects an existing profile by alias, so credentials stay in the config file rather than being exported into your environment. It never modifies the stored selection, so `spacectl profile select` in another shell is unaffected, and unsetting it returns you to the selected profile.
+
+`SPACELIFT_PROFILE` takes precedence over credentials supplied through the environment (`SPACELIFT_API_KEY_ID` and friends): naming a profile is deliberate, whereas those variables are easy to leave behind in a shell. If the named profile does not exist, `spacectl` reports that rather than falling back to another credential source.
+
 #### Overriding the config directory location
 
 By default profiles are stored in `${HOME}/.spacelift`. In containers or CI runners `$HOME` may not be set or writable, so you can point `spacectl` at a different directory with the `SPACELIFT_CONFIG_DIR` environment variable:

--- a/client/session/from_current_profile.go
+++ b/client/session/from_current_profile.go
@@ -14,7 +14,11 @@ func FromCurrentProfile(ctx context.Context, client *http.Client) (Session, erro
 		return nil, fmt.Errorf("could not access profile manager: %w", err)
 	}
 
-	currentProfile := manager.Current()
+	currentProfile, err := manager.CurrentValidated()
+	if err != nil {
+		return nil, err
+	}
+
 	if currentProfile == nil {
 		return nil, errors.New("no current profile is set - please login first")
 	}

--- a/client/session/new.go
+++ b/client/session/new.go
@@ -9,15 +9,30 @@ import (
 
 // New creates a session using the default chain of credentials sources:
 // first the environment, then the current credentials file.
+//
+// Naming a profile through SPACELIFT_PROFILE is an explicit choice, so it wins over credentials
+// that merely happen to be present in the environment: those are skipped entirely, rather than
+// risk authenticating as somebody other than the profile that was asked for.
 func New(ctx context.Context, client *http.Client) (Session, error) {
-	session, envErr := FromEnvironment(ctx, client)(os.LookupEnv)
-	if envErr == nil {
-		return session, nil
+	skipEnvironment := os.Getenv(EnvSpaceliftProfile) != ""
+
+	var envErr error
+	if !skipEnvironment {
+		session, err := FromEnvironment(ctx, client)(os.LookupEnv)
+		if err == nil {
+			return session, nil
+		}
+
+		envErr = err
 	}
 
 	session, fileErr := FromCurrentProfile(ctx, client)
 	if fileErr == nil {
 		return session, nil
+	}
+
+	if skipEnvironment {
+		return nil, fileErr
 	}
 
 	return nil, fmt.Errorf("could not build the session from the environment (%v) or file (%v)", envErr, fileErr)

--- a/client/session/new_test.go
+++ b/client/session/new_test.go
@@ -1,0 +1,148 @@
+package session
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"path"
+	"strings"
+	"testing"
+)
+
+// testJWT builds a JWT that FromAPIToken can parse. Only the audience and expiry
+// claims are read, and the signature is never verified, so a dummy one will do.
+func testJWT(t *testing.T, audience string) string {
+	t.Helper()
+
+	enc := func(segment string) string {
+		return base64.RawURLEncoding.EncodeToString([]byte(segment))
+	}
+
+	return strings.Join([]string{
+		enc(`{"alg":"HS256","typ":"JWT"}`),
+		enc(`{"aud":"` + audience + `","exp":1516239022}`),
+		enc("signature"),
+	}, ".")
+}
+
+// selectedProfileAlias is the one profile the New tests store; SPACELIFT_PROFILE points at
+// it (or deliberately does not) per case.
+const selectedProfileAlias = "other"
+
+// newSelectedProfile points SPACELIFT_CONFIG_DIR at a temporary directory holding a single
+// selected API token profile. It also clears every credential variable, so a session built
+// from the environment can only come from what the caller sets afterwards - not from
+// whatever the developer happens to have exported.
+func newSelectedProfile(t *testing.T, token string) {
+	t.Helper()
+
+	for _, name := range []string{
+		EnvSpaceliftAPIToken,
+		EnvSpaceliftAPIKeyID,
+		EnvSpaceliftAPIKeySecret,
+		EnvSpaceliftAPIKeyEndpoint,
+		EnvSpaceliftAPIEndpoint,
+		EnvSpaceliftAPIGitHubToken,
+	} {
+		t.Setenv(name, "")
+	}
+
+	t.Setenv(EnvSpaceliftConfigDirectory, path.Join(t.TempDir(), "profiles"))
+
+	manager, err := UserProfileManager()
+	if err != nil {
+		t.Fatalf("could not create profile manager: %v", err)
+	}
+
+	if err := manager.Create(&Profile{
+		Alias: selectedProfileAlias,
+		Credentials: &StoredCredentials{
+			Type:        CredentialsTypeAPIToken,
+			Endpoint:    "https://spacectl.app.spacelift.io",
+			AccessToken: token,
+		},
+	}); err != nil {
+		t.Fatalf("could not create profile %q: %v", selectedProfileAlias, err)
+	}
+}
+
+func assertToken(t *testing.T, sess Session, want string) {
+	t.Helper()
+
+	if sess == nil {
+		t.Fatal("expected a session, got nil")
+	}
+
+	token, err := sess.BearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("could not get bearer token: %v", err)
+	}
+
+	if token != want {
+		t.Fatalf("session was built from the wrong credentials source: got %q, want %q", token, want)
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Run("prefers the profile named by SPACELIFT_PROFILE over the environment", func(t *testing.T) {
+		profileToken := testJWT(t, "profile")
+		newSelectedProfile(t, profileToken)
+
+		// Credentials in the environment are valid, but naming a profile is deliberate.
+		t.Setenv(EnvSpaceliftAPIToken, testJWT(t, "environment"))
+		t.Setenv(EnvSpaceliftProfile, selectedProfileAlias)
+
+		sess, err := New(context.Background(), http.DefaultClient)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertToken(t, sess, profileToken)
+	})
+
+	t.Run("does not fall back to the environment when SPACELIFT_PROFILE is unknown", func(t *testing.T) {
+		newSelectedProfile(t, testJWT(t, "profile"))
+
+		t.Setenv(EnvSpaceliftAPIToken, testJWT(t, "environment"))
+		t.Setenv(EnvSpaceliftProfile, "typo")
+
+		sess, err := New(context.Background(), http.DefaultClient)
+		if err == nil {
+			t.Fatalf("expected an error, but a session was built instead: %v", sess)
+		}
+
+		if !strings.Contains(err.Error(), EnvSpaceliftProfile) {
+			t.Fatalf("error should name %s, got: %v", EnvSpaceliftProfile, err)
+		}
+	})
+
+	t.Run("uses the environment when SPACELIFT_PROFILE is not set", func(t *testing.T) {
+		environmentToken := testJWT(t, "environment")
+		newSelectedProfile(t, testJWT(t, "profile"))
+
+		t.Setenv(EnvSpaceliftAPIToken, environmentToken)
+		t.Setenv(EnvSpaceliftProfile, "")
+
+		sess, err := New(context.Background(), http.DefaultClient)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertToken(t, sess, environmentToken)
+	})
+
+	t.Run("falls back to the selected profile when the environment has no credentials", func(t *testing.T) {
+		profileToken := testJWT(t, "profile")
+		newSelectedProfile(t, profileToken)
+
+		t.Setenv(EnvSpaceliftAPIToken, "")
+		t.Setenv(EnvSpaceliftProfile, "")
+
+		sess, err := New(context.Background(), http.DefaultClient)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertToken(t, sess, profileToken)
+	})
+}

--- a/client/session/profile_manager.go
+++ b/client/session/profile_manager.go
@@ -20,6 +20,12 @@ const (
 	// when set, overrides the directory spacectl uses to store its profiles and
 	// configuration. When unset, spacectl falls back to ${HOME}/.spacelift.
 	EnvSpaceliftConfigDirectory = "SPACELIFT_CONFIG_DIR"
+
+	// EnvSpaceliftProfile is the name of the environment variable that, when set,
+	// selects the profile to use for the current process, without modifying the
+	// profile selected by `spacectl profile select`. When unset, the selected
+	// profile stored in the configuration is used.
+	EnvSpaceliftProfile = "SPACELIFT_PROFILE"
 )
 
 // invalidProfileAliases contains a list of strings that cannot be used as profile aliases.
@@ -51,6 +57,11 @@ type ProfileManager struct {
 
 	// The spacectl configuration.
 	Configuration *configuration
+
+	// The alias of the profile selected via SPACELIFT_PROFILE, if any. It takes
+	// precedence over the selected profile stored in the configuration, but is
+	// never persisted to it.
+	profileOverride string
 }
 
 // UserProfileManager creates a new ProfileManager using the user home directory to store the profile data.
@@ -92,6 +103,7 @@ func NewProfileManager(profilesDirectory string) (*ProfileManager, error) {
 
 	manager := &ProfileManager{
 		ConfigurationFile: filepath.Join(profilesDirectory, ConfigFileName),
+		profileOverride:   os.Getenv(EnvSpaceliftProfile),
 	}
 
 	if err := manager.loadConfiguration(); err != nil {
@@ -111,12 +123,49 @@ func (m *ProfileManager) Get(profileAlias string) (*Profile, error) {
 }
 
 // Current gets the user's currently selected profile, and returns nil if no profile is selected.
+// A profile selected via SPACELIFT_PROFILE takes precedence over the one stored in the configuration.
 func (m *ProfileManager) Current() *Profile {
-	if m.Configuration.CurrentProfileAlias == "" {
+	alias := m.Configuration.CurrentProfileAlias
+	if m.profileOverride != "" {
+		alias = m.profileOverride
+	}
+
+	if alias == "" {
 		return nil
 	}
 
-	return m.Configuration.Profiles[m.Configuration.CurrentProfileAlias]
+	return m.Configuration.Profiles[alias]
+}
+
+// CurrentValidated returns the same profile as Current, but reports an error when
+// SPACELIFT_PROFILE names a profile that does not exist - the one case Current cannot
+// distinguish from "no profile is selected". Prefer it over Current wherever a nil profile
+// would otherwise be reported to the user as a missing login.
+func (m *ProfileManager) CurrentValidated() (*Profile, error) {
+	if err := m.ValidateProfileOverride(); err != nil {
+		return nil, err
+	}
+
+	return m.Current(), nil
+}
+
+// ProfileOverride returns the profile alias set via SPACELIFT_PROFILE, and whether it was set at all.
+func (m *ProfileManager) ProfileOverride() (string, bool) {
+	return m.profileOverride, m.profileOverride != ""
+}
+
+// ValidateProfileOverride returns a descriptive error if SPACELIFT_PROFILE names a profile that does
+// not exist, so that a typo surfaces as such instead of looking like a missing login. It returns nil
+// if the variable is unset or names an existing profile.
+func (m *ProfileManager) ValidateProfileOverride() error {
+	if m.profileOverride == "" || m.Configuration.Profiles[m.profileOverride] != nil {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s is set to '%s', but no profile with that alias exists - run `spacectl profile login %s`, or unset %s to use the selected profile",
+		EnvSpaceliftProfile, m.profileOverride, m.profileOverride, EnvSpaceliftProfile,
+	)
 }
 
 // Select sets the currently selected profile.
@@ -135,14 +184,22 @@ func (m *ProfileManager) Select(profileAlias string) error {
 	return m.writeConfigurationToFile()
 }
 
-// Create adds a new Spacelift profile.
+// Create adds a new Spacelift profile, and selects it unless doing so would persist the
+// profile named by SPACELIFT_PROFILE. Re-authenticating that profile - what `spacectl profile
+// login` with no alias does - must not turn a per-shell choice into the stored selection.
+// A brand new profile is still selected, so logging in for the first time behaves as before.
 func (m *ProfileManager) Create(profile *Profile) error {
 	if err := validateProfile(profile); err != nil {
 		return err
 	}
 
+	_, alreadyExists := m.Configuration.Profiles[profile.Alias]
+	reauthenticatingOverride := m.profileOverride == profile.Alias && alreadyExists
+
 	m.Configuration.Profiles[profile.Alias] = profile
-	m.Configuration.CurrentProfileAlias = profile.Alias
+	if !reauthenticatingOverride {
+		m.Configuration.CurrentProfileAlias = profile.Alias
+	}
 
 	return m.writeConfigurationToFile()
 }

--- a/client/session/profile_manager_test.go
+++ b/client/session/profile_manager_test.go
@@ -71,6 +71,119 @@ func TestProfileManager(t *testing.T) {
 					gomega.Expect(profile).To(gomega.BeNil())
 				})
 			})
+
+			g.Describe("SPACELIFT_PROFILE is set", func() {
+				// The manager reads the variable at construction, so each case creates its
+				// own manager after setting it.
+				newManagerWithOverride := func(alias string) *session.ProfileManager {
+					gomega.Expect(os.Setenv(session.EnvSpaceliftProfile, alias)).To(gomega.Succeed())
+
+					overriddenManager, err := session.NewProfileManager(profilesDirectory)
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+					return overriddenManager
+				}
+
+				g.AfterEach(func() {
+					_ = os.Unsetenv(session.EnvSpaceliftProfile)
+				})
+
+				g.It("takes precedence over the selected profile", func() {
+					gomega.Expect(manager.Create(createValidProfile("profile1"))).To(gomega.Succeed())
+					gomega.Expect(manager.Create(createValidProfile("profile2"))).To(gomega.Succeed())
+					gomega.Expect(manager.Select("profile1")).To(gomega.Succeed())
+
+					overriddenManager := newManagerWithOverride("profile2")
+
+					current := overriddenManager.Current()
+					gomega.Expect(current).ToNot(gomega.BeNil())
+					gomega.Expect(current.Alias).To(gomega.Equal("profile2"))
+					gomega.Expect(overriddenManager.ValidateProfileOverride()).To(gomega.Succeed())
+				})
+
+				g.It("does not persist the override to the configuration", func() {
+					gomega.Expect(manager.Create(createValidProfile("profile1"))).To(gomega.Succeed())
+					gomega.Expect(manager.Create(createValidProfile("profile2"))).To(gomega.Succeed())
+					gomega.Expect(manager.Select("profile1")).To(gomega.Succeed())
+
+					overriddenManager := newManagerWithOverride("profile2")
+					// Any write must leave the stored selection alone.
+					gomega.Expect(overriddenManager.Create(createValidProfile("profile3"))).To(gomega.Succeed())
+
+					gomega.Expect(os.Unsetenv(session.EnvSpaceliftProfile)).To(gomega.Succeed())
+					reloaded, err := session.NewProfileManager(profilesDirectory)
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+					// profile3 was just created, so it legitimately becomes the selected profile;
+					// what matters is that profile2 never leaked into the stored configuration.
+					gomega.Expect(reloaded.Configuration.CurrentProfileAlias).To(gomega.Equal("profile3"))
+				})
+
+				g.It("does not persist the override when re-authenticating it", func() {
+					// `spacectl profile login` with no alias re-authenticates the profile in
+					// use - which is the override - and must not turn it into the selection
+					// every other shell then picks up.
+					gomega.Expect(manager.Create(createValidProfile("profile1"))).To(gomega.Succeed())
+					gomega.Expect(manager.Create(createValidProfile("profile2"))).To(gomega.Succeed())
+					gomega.Expect(manager.Select("profile1")).To(gomega.Succeed())
+
+					overriddenManager := newManagerWithOverride("profile2")
+					gomega.Expect(overriddenManager.Create(createValidProfile("profile2"))).To(gomega.Succeed())
+
+					gomega.Expect(os.Unsetenv(session.EnvSpaceliftProfile)).To(gomega.Succeed())
+					reloaded, err := session.NewProfileManager(profilesDirectory)
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+					gomega.Expect(reloaded.Configuration.CurrentProfileAlias).To(gomega.Equal("profile1"))
+					// The credentials were still rewritten, so the re-auth itself took effect.
+					gomega.Expect(reloaded.Configuration.Profiles).To(gomega.HaveKey("profile2"))
+				})
+
+				g.It("selects a profile that is not the one stored as current", func() {
+					gomega.Expect(manager.Create(createValidProfile("profile1"))).To(gomega.Succeed())
+					gomega.Expect(manager.Create(createValidProfile("profile2"))).To(gomega.Succeed())
+
+					overriddenManager := newManagerWithOverride("profile1")
+
+					// Select writes profile2, but the override still wins for reads.
+					gomega.Expect(overriddenManager.Select("profile2")).To(gomega.Succeed())
+
+					current := overriddenManager.Current()
+					gomega.Expect(current).ToNot(gomega.BeNil())
+					gomega.Expect(current.Alias).To(gomega.Equal("profile1"))
+				})
+
+				g.It("reports the override alias", func() {
+					gomega.Expect(manager.Create(createValidProfile("profile1"))).To(gomega.Succeed())
+
+					override, ok := newManagerWithOverride("profile1").ProfileOverride()
+
+					gomega.Expect(ok).To(gomega.BeTrue())
+					gomega.Expect(override).To(gomega.Equal("profile1"))
+				})
+
+				g.It("returns a descriptive error when the profile does not exist", func() {
+					gomega.Expect(manager.Create(createValidProfile("profile1"))).To(gomega.Succeed())
+
+					overriddenManager := newManagerWithOverride("typo")
+
+					gomega.Expect(overriddenManager.Current()).To(gomega.BeNil())
+					gomega.Expect(overriddenManager.ValidateProfileOverride()).Should(gomega.MatchError(
+						"SPACELIFT_PROFILE is set to 'typo', but no profile with that alias exists - " +
+							"run `spacectl profile login typo`, or unset SPACELIFT_PROFILE to use the selected profile",
+					))
+				})
+			})
+
+			g.Describe("SPACELIFT_PROFILE is not set", func() {
+				g.It("reports no override and validates successfully", func() {
+					override, ok := manager.ProfileOverride()
+
+					gomega.Expect(ok).To(gomega.BeFalse())
+					gomega.Expect(override).To(gomega.BeEmpty())
+					gomega.Expect(manager.ValidateProfileOverride()).To(gomega.Succeed())
+				})
+			})
 		})
 
 		g.Describe("Create", func() {

--- a/internal/cmd/profile/current_command.go
+++ b/internal/cmd/profile/current_command.go
@@ -16,7 +16,10 @@ func currentCommand() *cli.Command {
 		Usage:     "Outputs your currently selected profile",
 		ArgsUsage: cmd.EmptyArgsUsage,
 		Action: func(_ context.Context, _ *cli.Command) error {
-			currentProfile := manager.Current()
+			currentProfile, err := manager.CurrentValidated()
+			if err != nil {
+				return err
+			}
 
 			if currentProfile == nil {
 				return errors.New("no account is currently selected")

--- a/internal/cmd/profile/export_token.go
+++ b/internal/cmd/profile/export_token.go
@@ -46,7 +46,14 @@ func exportTokenCommand() *cli.Command {
 // without anyone having to hand-roll the apiKeyUser GraphQL mutation.
 func resolveSession(ctx context.Context, m *session.ProfileManager, httpClient *http.Client, lookup func(string) (string, bool)) (session.Session, error) {
 	if m != nil {
-		if current := m.Current(); current != nil {
+		// Naming a profile through SPACELIFT_PROFILE is an explicit choice, so a bad alias is
+		// an error rather than a reason to fall back and print a token for a different account.
+		current, err := m.CurrentValidated()
+		if err != nil {
+			return nil, err
+		}
+
+		if current != nil {
 			return current.Credentials.Session(ctx, httpClient)
 		}
 	}

--- a/internal/cmd/profile/export_token_test.go
+++ b/internal/cmd/profile/export_token_test.go
@@ -2,9 +2,11 @@ package profile
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/spacelift-io/spacectl/client/session"
@@ -24,6 +26,11 @@ func envLookup(values map[string]string) func(string) (string, bool) {
 }
 
 func TestResolveSession(t *testing.T) {
+	// resolveSession rejects an unresolvable SPACELIFT_PROFILE, so a value left in the
+	// developer's own shell would fail the cases below. Subtests that want an override set
+	// it themselves after this.
+	t.Setenv(session.EnvSpaceliftProfile, "")
+
 	t.Run("falls back to the environment when no profile manager is set", func(t *testing.T) {
 		server := newExchangeServer(t, "EnvJWT")
 		defer server.Close()
@@ -99,6 +106,97 @@ func TestResolveSession(t *testing.T) {
 
 		assertBearerToken(t, sess, sampleAPIToken)
 	})
+
+	t.Run("uses the profile named by SPACELIFT_PROFILE", func(t *testing.T) {
+		t.Setenv(session.EnvSpaceliftProfile, "override")
+
+		manager := managerWithAPITokenProfiles(t, "selected", "override")
+
+		lookup := envLookup(map[string]string{
+			session.EnvSpaceliftAPIKeyEndpoint: "http://127.0.0.1:0",
+			session.EnvSpaceliftAPIKeyID:       "key-id",
+			session.EnvSpaceliftAPIKeySecret:   "oidc-token",
+		})
+
+		sess, err := resolveSession(context.Background(), manager, http.DefaultClient, lookup)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Each profile carries a token named after its alias, so the bearer token
+		// says which profile the session was actually built from.
+		assertBearerToken(t, sess, aliasToken("override"))
+	})
+
+	t.Run("does not fall back to the environment when SPACELIFT_PROFILE is unknown", func(t *testing.T) {
+		t.Setenv(session.EnvSpaceliftProfile, "typo")
+
+		manager := managerWithAPITokenProfiles(t, "selected")
+
+		// Valid credentials in the environment must not rescue a bad alias: exporting a
+		// token for a different account is worse than failing.
+		server := newExchangeServer(t, "EnvJWT")
+		defer server.Close()
+
+		lookup := envLookup(map[string]string{
+			session.EnvSpaceliftAPIKeyEndpoint: server.URL,
+			session.EnvSpaceliftAPIKeyID:       "key-id",
+			session.EnvSpaceliftAPIKeySecret:   "oidc-token",
+		})
+
+		sess, err := resolveSession(context.Background(), manager, server.Client(), lookup)
+		if err == nil {
+			t.Fatalf("expected an error, but a session was built instead: %v", sess)
+		}
+
+		if !strings.Contains(err.Error(), session.EnvSpaceliftProfile) {
+			t.Fatalf("error should name %s, got: %v", session.EnvSpaceliftProfile, err)
+		}
+	})
+}
+
+// aliasToken returns a JWT unique to a profile alias, so that assertions can tell
+// which profile a session came from.
+func aliasToken(alias string) string {
+	enc := func(segment string) string {
+		return base64.RawURLEncoding.EncodeToString([]byte(segment))
+	}
+
+	return strings.Join([]string{
+		enc(`{"alg":"HS256","typ":"JWT"}`),
+		enc(`{"aud":"` + alias + `","exp":1516239022}`),
+		enc("signature"),
+	}, ".")
+}
+
+// managerWithAPITokenProfiles creates an API token profile per alias in a temporary
+// directory. The first alias ends up selected, mirroring `spacectl profile select`.
+func managerWithAPITokenProfiles(t *testing.T, aliases ...string) *session.ProfileManager {
+	t.Helper()
+
+	manager, err := session.NewProfileManager(path.Join(t.TempDir(), "profiles"))
+	if err != nil {
+		t.Fatalf("could not create profile manager: %v", err)
+	}
+
+	for _, alias := range aliases {
+		if err := manager.Create(&session.Profile{
+			Alias: alias,
+			Credentials: &session.StoredCredentials{
+				Type:        session.CredentialsTypeAPIToken,
+				Endpoint:    "https://spacectl.app.spacelift.io",
+				AccessToken: aliasToken(alias),
+			},
+		}); err != nil {
+			t.Fatalf("could not create profile %q: %v", alias, err)
+		}
+	}
+
+	if err := manager.Select(aliases[0]); err != nil {
+		t.Fatalf("could not select profile %q: %v", aliases[0], err)
+	}
+
+	return manager
 }
 
 // newExchangeServer returns a mock GraphQL server that answers the apiKeyUser

--- a/internal/cmd/profile/get_alias_with_profile.go
+++ b/internal/cmd/profile/get_alias_with_profile.go
@@ -12,6 +12,12 @@ import (
 
 var (
 	apiTokenProfile *session.Profile
+
+	// aliasFromArgs records whether the alias came from the command line rather than from
+	// the profile in use. Persisting the login depends on the difference: an alias the user
+	// typed is a deliberate choice, so it becomes the stored selection even when
+	// SPACELIFT_PROFILE names the same profile.
+	aliasFromArgs bool
 )
 
 func getAliasWithAPITokenProfile(ctx context.Context, cliCmd *cli.Command) (context.Context, error) {
@@ -19,6 +25,8 @@ func getAliasWithAPITokenProfile(ctx context.Context, cliCmd *cli.Command) (cont
 	if err != nil {
 		return ctx, err
 	}
+
+	aliasFromArgs = ok
 
 	if ok {
 		return ctx, nil
@@ -29,7 +37,13 @@ func getAliasWithAPITokenProfile(ctx context.Context, cliCmd *cli.Command) (cont
 		return ctx, fmt.Errorf("could not accesss profile manager: %w", err)
 	}
 
-	profile := manager.Current()
+	// Only this branch depends on the override resolving, so validate here rather than for
+	// the whole command: `SPACELIFT_PROFILE=new spacectl profile login new` must stay able
+	// to create the profile the variable names.
+	profile, err := manager.CurrentValidated()
+	if err != nil {
+		return ctx, err
+	}
 	if profile != nil && profile.Credentials.Type == session.CredentialsTypeAPIToken {
 		apiTokenProfile = profile
 	} else {

--- a/internal/cmd/profile/list_command.go
+++ b/internal/cmd/profile/list_command.go
@@ -29,9 +29,15 @@ func listCommand() *cli.Command {
 		ArgsUsage: cmd.EmptyArgsUsage,
 		Before:    cmd.HandleNoColor,
 		Action: func(_ context.Context, cliCmd *cli.Command) error {
-			profiles := manager.GetAll()
+			// Without the validated variant, a typo'd SPACELIFT_PROFILE just leaves every
+			// row unmarked - no answer at all from the command people use to ask which
+			// profile is active.
+			currentProfile, err := manager.CurrentValidated()
+			if err != nil {
+				return err
+			}
 
-			currentProfile := manager.Current()
+			profiles := manager.GetAll()
 
 			// Make sure we output the profiles in a consistent order
 			sort.SliceStable(profiles, func(i int, j int) bool {
@@ -39,7 +45,6 @@ func listCommand() *cli.Command {
 			})
 
 			var outputFormat cmd.OutputFormat
-			var err error
 			if outputFormat, err = cmd.GetOutputFormat(cliCmd); err != nil {
 				return err
 			}

--- a/internal/cmd/profile/login_command.go
+++ b/internal/cmd/profile/login_command.go
@@ -222,13 +222,33 @@ func loginUsingWebBrowser(ctx context.Context, _ *cli.Command, creds *session.St
 }
 
 func persistAccessCredentials(creds *session.StoredCredentials) error {
-	return manager.Create(&session.Profile{
+	if err := manager.Create(&session.Profile{
 		Alias:       profileAlias,
 		Credentials: creds,
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Create leaves the stored selection alone when it is re-authenticating the profile
+	// SPACELIFT_PROFILE names, so that a per-shell choice is never persisted. An alias typed
+	// on the command line is a different thing entirely, and still selects.
+	if aliasFromArgs && manager.Configuration.CurrentProfileAlias != profileAlias {
+		return manager.Select(profileAlias)
+	}
+
+	return nil
 }
 
 func printEnvWarning() {
+	override := os.Getenv(session.EnvSpaceliftProfile)
+
+	// SPACELIFT_PROFILE selects a profile rather than supplying credentials, so it gets its own
+	// warning - but only when it names a profile other than the one just logged into.
+	if override != "" && override != profileAlias {
+		fmt.Printf("WARNING: %s is set to '%s', and takes precedence over the profile selected by logging in.\n",
+			session.EnvSpaceliftProfile, override)
+	}
+
 	envVars := checkEnvironmentVariables()
 	if len(envVars) == 0 {
 		return
@@ -238,6 +258,14 @@ func printEnvWarning() {
 	for _, envVar := range envVars {
 		fmt.Printf("   - %s\n", envVar)
 	}
+
+	// Naming a profile skips the environment entirely, so the usual precedence advice would
+	// be backwards here.
+	if override != "" {
+		fmt.Printf("\nThese are ignored while %s is set.\n", session.EnvSpaceliftProfile)
+		return
+	}
+
 	fmt.Println("\nEnvironment variables take precedence over profile credentials.")
 	fmt.Println("If these credentials are expired or invalid, commands will fail even after successful login.")
 }

--- a/internal/cmd/profile/override_test.go
+++ b/internal/cmd/profile/override_test.go
@@ -1,0 +1,357 @@
+package profile
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/spacelift-io/spacectl/client/session"
+)
+
+// newConfigDir points SPACELIFT_CONFIG_DIR at a temporary directory holding one API token
+// profile per alias, the first of which is selected.
+func newConfigDir(t *testing.T, aliases ...string) {
+	t.Helper()
+
+	dir := path.Join(t.TempDir(), "profiles")
+	t.Setenv(session.EnvSpaceliftConfigDirectory, dir)
+
+	manager, err := session.NewProfileManager(dir)
+	if err != nil {
+		t.Fatalf("could not create profile manager: %v", err)
+	}
+
+	for _, alias := range aliases {
+		if err := manager.Create(&session.Profile{
+			Alias: alias,
+			Credentials: &session.StoredCredentials{
+				Type:        session.CredentialsTypeAPIToken,
+				Endpoint:    "https://spacectl.app.spacelift.io",
+				AccessToken: sampleAPIToken,
+			},
+		}); err != nil {
+			t.Fatalf("could not create profile %q: %v", alias, err)
+		}
+	}
+
+	if err := manager.Select(aliases[0]); err != nil {
+		t.Fatalf("could not select profile %q: %v", aliases[0], err)
+	}
+}
+
+// newManager sets the package-level manager the commands use, the way the profile subtree's
+// Before hook does. Call it after SPACELIFT_PROFILE is set: the manager captures the override
+// at construction, so the order matters.
+func newManager(t *testing.T) {
+	t.Helper()
+
+	var err error
+	if manager, err = session.UserProfileManager(); err != nil {
+		t.Fatalf("could not create profile manager: %v", err)
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected, and returns what it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("could not create pipe: %v", err)
+	}
+	os.Stdout = writer
+
+	fn()
+
+	os.Stdout = original
+	if err := writer.Close(); err != nil {
+		t.Fatalf("could not close pipe: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, reader); err != nil {
+		t.Fatalf("could not read pipe: %v", err)
+	}
+
+	return buf.String()
+}
+
+// runLoginBefore runs `profile login` through the real command tree - so the profile
+// subtree's own Before hook runs too - far enough to exercise login's Before hook, with the
+// action stubbed out so the interactive flow never starts.
+func runLoginBefore(t *testing.T, args ...string) error {
+	t.Helper()
+
+	parent := Command()
+	for _, subcommand := range parent.Commands {
+		if subcommand.Name == "login" {
+			subcommand.Action = func(context.Context, *cli.Command) error { return nil }
+		}
+	}
+
+	return parent.Run(context.Background(), append([]string{"profile", "login"}, args...))
+}
+
+// TestProfileOverrideIsValidated covers the ValidateProfileOverride guards on the commands
+// that resolve the selected profile. An alias naming no profile must stop them with a message
+// naming the variable, rather than being swallowed as "nothing is selected" - while still
+// leaving `profile login <alias>` able to create that very profile.
+func TestProfileOverrideIsValidated(t *testing.T) {
+	for _, subcommand := range []string{"current", "list"} {
+		t.Run(subcommand+" rejects an unknown SPACELIFT_PROFILE", func(t *testing.T) {
+			newConfigDir(t, "selected")
+			t.Setenv(session.EnvSpaceliftProfile, "typo")
+
+			err := Command().Run(context.Background(), []string{"profile", subcommand})
+			if err == nil {
+				t.Fatal("expected an error, got none")
+			}
+
+			if !strings.Contains(err.Error(), session.EnvSpaceliftProfile) {
+				t.Fatalf("error should name %s, got: %v", session.EnvSpaceliftProfile, err)
+			}
+			if !strings.Contains(err.Error(), "typo") {
+				t.Fatalf("error should name the bad alias, got: %v", err)
+			}
+		})
+
+		t.Run(subcommand+" accepts a known SPACELIFT_PROFILE", func(t *testing.T) {
+			newConfigDir(t, "selected", "other")
+			t.Setenv(session.EnvSpaceliftProfile, "other")
+
+			if err := Command().Run(context.Background(), []string{"profile", subcommand}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+
+	t.Run("login can still create the profile the override names", func(t *testing.T) {
+		// Validating the override for the whole subtree would make this bootstrap
+		// impossible, and the error would tell the user to run the command that just
+		// failed. login only needs the override to resolve when no alias is given.
+		newConfigDir(t, "selected")
+		t.Setenv(session.EnvSpaceliftProfile, "brandnew")
+		t.Cleanup(func() { profileAlias = "" })
+
+		// The Before hook is what validates; stub the Action so the test does not enter
+		// the interactive login flow.
+		if err := runLoginBefore(t, "brandnew"); err != nil {
+			t.Fatalf("naming an alias explicitly should not require the override to exist: %v", err)
+		}
+	})
+
+	t.Run("login with no alias rejects an unknown override", func(t *testing.T) {
+		newConfigDir(t, "selected")
+		t.Setenv(session.EnvSpaceliftProfile, "typo")
+		t.Cleanup(func() { profileAlias = "" })
+
+		err := runLoginBefore(t)
+		if err == nil {
+			t.Fatal("expected an error, got none")
+		}
+		if !strings.Contains(err.Error(), session.EnvSpaceliftProfile) {
+			t.Fatalf("error should name %s, got: %v", session.EnvSpaceliftProfile, err)
+		}
+	})
+
+	t.Run("current reports the overridden profile", func(t *testing.T) {
+		newConfigDir(t, "selected", "other")
+		t.Setenv(session.EnvSpaceliftProfile, "other")
+
+		out := captureStdout(t, func() {
+			if err := Command().Run(context.Background(), []string{"profile", "current"}); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+
+		if strings.TrimSpace(out) != "other" {
+			t.Fatalf("expected the override alias, got %q", strings.TrimSpace(out))
+		}
+	})
+}
+
+// TestPersistAccessCredentialsSelection covers which logins change the stored selection.
+// Re-authenticating the profile SPACELIFT_PROFILE names must leave it alone, because the
+// variable is per-shell; an alias the user typed must still select, because that is a
+// deliberate choice the variable should not swallow.
+func TestPersistAccessCredentialsSelection(t *testing.T) {
+	login := func(t *testing.T, alias string, fromArgs bool) string {
+		t.Helper()
+
+		profileAlias = alias
+		aliasFromArgs = fromArgs
+		t.Cleanup(func() { profileAlias = ""; aliasFromArgs = false })
+
+		if err := persistAccessCredentials(&session.StoredCredentials{
+			Type:        session.CredentialsTypeAPIToken,
+			Endpoint:    "https://spacectl.app.spacelift.io",
+			AccessToken: sampleAPIToken,
+		}); err != nil {
+			t.Fatalf("could not persist credentials: %v", err)
+		}
+
+		reloaded, err := session.UserProfileManager()
+		if err != nil {
+			t.Fatalf("could not reload profile manager: %v", err)
+		}
+
+		return reloaded.Configuration.CurrentProfileAlias
+	}
+
+	t.Run("re-authenticating the override does not change the stored selection", func(t *testing.T) {
+		newConfigDir(t, "selected", "other")
+		t.Setenv(session.EnvSpaceliftProfile, "other")
+		newManager(t)
+
+		if got := login(t, "other", false); got != "selected" {
+			t.Fatalf("the override leaked into the stored selection: got %q, want %q", got, "selected")
+		}
+	})
+
+	t.Run("an alias typed on the command line still selects", func(t *testing.T) {
+		newConfigDir(t, "selected", "other")
+		t.Setenv(session.EnvSpaceliftProfile, "other")
+		newManager(t)
+
+		// `spacectl profile login other` while SPACELIFT_PROFILE=other: the user named it,
+		// so it must take effect rather than being mistaken for a re-auth.
+		if got := login(t, "other", true); got != "other" {
+			t.Fatalf("an explicitly named alias was not selected: got %q, want %q", got, "other")
+		}
+	})
+
+	t.Run("logging in without an override selects as usual", func(t *testing.T) {
+		newConfigDir(t, "selected", "other")
+		t.Setenv(session.EnvSpaceliftProfile, "")
+		newManager(t)
+
+		if got := login(t, "other", true); got != "other" {
+			t.Fatalf("expected the login to select the profile: got %q", got)
+		}
+	})
+}
+
+// TestSelectWarnsWhenOverridden covers the warning `profile select` prints when the stored
+// selection it just wrote will be shadowed by SPACELIFT_PROFILE.
+func TestSelectWarnsWhenOverridden(t *testing.T) {
+	const warning = "takes precedence over the profile you just selected"
+
+	selectProfile := func(t *testing.T, alias string) string {
+		t.Helper()
+
+		return captureStdout(t, func() {
+			if err := Command().Run(context.Background(), []string{"profile", "select", alias}); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+
+	t.Run("warns when the override names a different profile", func(t *testing.T) {
+		newConfigDir(t, "selected", "other")
+		t.Setenv(session.EnvSpaceliftProfile, "other")
+		t.Cleanup(func() { profileAlias = "" })
+
+		out := selectProfile(t, "selected")
+
+		if !strings.Contains(out, warning) {
+			t.Fatalf("expected the override warning, got %q", out)
+		}
+
+		// The selection is still written - the warning says it will not take effect in
+		// this shell, not that it was refused.
+		reloaded, err := session.UserProfileManager()
+		if err != nil {
+			t.Fatalf("could not reload profile manager: %v", err)
+		}
+		if got := reloaded.Configuration.CurrentProfileAlias; got != "selected" {
+			t.Fatalf("expected the selection to be persisted, got %q", got)
+		}
+	})
+
+	t.Run("stays silent when the override names the profile being selected", func(t *testing.T) {
+		newConfigDir(t, "selected", "other")
+		t.Setenv(session.EnvSpaceliftProfile, "other")
+		t.Cleanup(func() { profileAlias = "" })
+
+		if out := selectProfile(t, "other"); strings.Contains(out, warning) {
+			t.Fatalf("expected no warning when selecting the overridden profile, got %q", out)
+		}
+	})
+
+	t.Run("stays silent when no override is set", func(t *testing.T) {
+		newConfigDir(t, "selected", "other")
+		t.Setenv(session.EnvSpaceliftProfile, "")
+		t.Cleanup(func() { profileAlias = "" })
+
+		if out := selectProfile(t, "other"); strings.Contains(out, warning) {
+			t.Fatalf("expected no warning without an override, got %q", out)
+		}
+	})
+}
+
+// TestPrintEnvWarning covers the two messages login prints about SPACELIFT_PROFILE: the
+// override warning must not fire for the profile being logged into, and the usual
+// "environment takes precedence" advice is backwards while an override is set.
+func TestPrintEnvWarning(t *testing.T) {
+	const overrideWarning = "takes precedence over the profile selected by logging in"
+
+	t.Run("warns when the override names a different profile", func(t *testing.T) {
+		t.Setenv(session.EnvSpaceliftProfile, "other")
+		profileAlias = "selected"
+		t.Cleanup(func() { profileAlias = "" })
+
+		out := captureStdout(t, printEnvWarning)
+
+		if !strings.Contains(out, overrideWarning) {
+			t.Fatalf("expected the override warning, got %q", out)
+		}
+	})
+
+	t.Run("stays silent when the override names the profile being logged into", func(t *testing.T) {
+		t.Setenv(session.EnvSpaceliftProfile, "selected")
+		profileAlias = "selected"
+		t.Cleanup(func() { profileAlias = "" })
+
+		out := captureStdout(t, printEnvWarning)
+
+		if strings.Contains(out, overrideWarning) {
+			t.Fatalf("expected no override warning, got %q", out)
+		}
+	})
+
+	t.Run("says environment credentials are ignored while the override is set", func(t *testing.T) {
+		t.Setenv(session.EnvSpaceliftProfile, "other")
+		t.Setenv(session.EnvSpaceliftAPIToken, sampleAPIToken)
+		profileAlias = "selected"
+		t.Cleanup(func() { profileAlias = "" })
+
+		out := captureStdout(t, printEnvWarning)
+
+		if !strings.Contains(out, "ignored while "+session.EnvSpaceliftProfile+" is set") {
+			t.Fatalf("expected the ignored-variables note, got %q", out)
+		}
+		if strings.Contains(out, "Environment variables take precedence") {
+			t.Fatalf("precedence advice is backwards while the override is set, got %q", out)
+		}
+	})
+
+	t.Run("keeps the precedence advice when no override is set", func(t *testing.T) {
+		t.Setenv(session.EnvSpaceliftProfile, "")
+		t.Setenv(session.EnvSpaceliftAPIToken, sampleAPIToken)
+		profileAlias = "selected"
+		t.Cleanup(func() { profileAlias = "" })
+
+		out := captureStdout(t, printEnvWarning)
+
+		if !strings.Contains(out, "Environment variables take precedence") {
+			t.Fatalf("expected the precedence advice, got %q", out)
+		}
+	})
+}

--- a/internal/cmd/profile/select_command.go
+++ b/internal/cmd/profile/select_command.go
@@ -2,8 +2,11 @@ package profile
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/urfave/cli/v3"
+
+	"github.com/spacelift-io/spacectl/client/session"
 )
 
 func selectCommand() *cli.Command {
@@ -16,7 +19,21 @@ func selectCommand() *cli.Command {
 			return ctx, err
 		},
 		Action: func(ctx context.Context, cliCmd *cli.Command) error {
-			return manager.Select(profileAlias)
+			if err := manager.Select(profileAlias); err != nil {
+				return err
+			}
+
+			// The selection was persisted, but this shell won't act on it, so say so rather
+			// than letting the user believe the switch took effect.
+			if override, ok := manager.ProfileOverride(); ok && override != profileAlias {
+				fmt.Printf(
+					"WARNING: %s is set to '%s', which takes precedence over the profile you just selected.\n"+
+						"Unset %s for '%s' to take effect in this shell.\n",
+					session.EnvSpaceliftProfile, override, session.EnvSpaceliftProfile, profileAlias,
+				)
+			}
+
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
## Description

Adds `SPACELIFT_PROFILE`, which selects an existing profile by alias for a single command or shell, without changing the profile stored by `spacectl profile select`.

## Type of Change

- [x] New feature

## Changes Made

- `SPACELIFT_PROFILE` overrides the selected profile in `ProfileManager.Current()`. It is read once in `NewProfileManager` and never persisted, so `profile select` in another shell is unaffected.
- It takes precedence over credentials in the environment (`SPACELIFT_API_KEY_ID` and friends), and does not fall back to them if the profile fails: naming a profile is deliberate, whereas those variables are easy to leave set in a shell.
- An unknown alias is reported as such instead of surfacing as "no current profile is set".
- `profile select` and `profile login` warn when the variable is set, matching the existing warning from #358.
- Files: `client/session/{profile_manager,new,from_current_profile}.go`, `internal/cmd/profile/{current,select,login}_command.go`, `README.md`.

No GraphQL API features are involved, so no command versioning is needed.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed
- [x] All existing tests pass

Verified against a real account that each profile resolves to its own API key, and that `~/.spacelift/config.json` is unmodified. `gofmt -s`, `go vet ./...`, `golangci-lint run` and `go test ./...` are clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Related Issues

Related to #381, which requested exactly this. It is closed, so this PR cannot close it automatically - a maintainer may want to reopen it. The reporter noted they lacked permission to do so themselves.

---

This contribution was developed with the assistance of AI tools, and reviewed and tested before submitting.