### PR TITLE
refactor: use the non-deprecated policy simulate and blueprint stack fields

### DIFF
--- a/internal/cmd/blueprint/deploy.go
+++ b/internal/cmd/blueprint/deploy.go
@@ -44,7 +44,7 @@ func (c *deployCommand) deploy(ctx context.Context, cliCmd *cli.Command) error {
 
 	var mutation struct {
 		BlueprintCreateStack struct {
-			StackID string `graphql:"stackID"`
+			StackIDs []string `graphql:"stackIds"`
 		} `graphql:"blueprintCreateStack(id: $id, input: $input)"`
 	}
 
@@ -56,8 +56,9 @@ func (c *deployCommand) deploy(ctx context.Context, cliCmd *cli.Command) error {
 		return fmt.Errorf("failed to deploy stack from the blueprint: %w", err)
 	}
 
-	url := authenticated.Client().URL("/stack/%s", mutation.BlueprintCreateStack.StackID)
-	fmt.Printf("\nCreated stack: %q", url)
+	for _, stackID := range mutation.BlueprintCreateStack.StackIDs {
+		fmt.Printf("\nCreated stack: %q", authenticated.Client().URL("/stack/%s", stackID))
+	}
 
 	return nil
 }

--- a/internal/cmd/policy/simulate.go
+++ b/internal/cmd/policy/simulate.go
@@ -7,12 +7,18 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/shurcooL/graphql"
 	"github.com/urfave/cli/v3"
 
 	"github.com/spacelift-io/spacectl/internal/cmd"
 	"github.com/spacelift-io/spacectl/internal/cmd/authenticated"
 )
+
+// PolicySimulateInput represents the input for simulating a policy.
+type PolicySimulateInput struct {
+	Body  string     `json:"body"`
+	Input string     `json:"input"`
+	Type  PolicyType `json:"type"`
+}
 
 type simulateCommand struct{}
 
@@ -35,13 +41,15 @@ func (c *simulateCommand) simulate(ctx context.Context, cliCmd *cli.Command) err
 	}
 
 	var mutation struct {
-		PolicySimulate string `graphql:"policySimulate(body: $body, input: $input, type: $type)"`
+		PolicySimulate string `graphql:"policySimulatev2(input: $input)"`
 	}
 
 	variables := map[string]any{
-		"body":  graphql.String(b.Body),
-		"input": graphql.String(parsedInput),
-		"type":  b.Type,
+		"input": PolicySimulateInput{
+			Body:  b.Body,
+			Input: parsedInput,
+			Type:  b.Type,
+		},
 	}
 
 	if err := authenticated.Client().Mutate(ctx, &mutation, variables); err != nil {


### PR DESCRIPTION
## Description

Two commands were still calling GraphQL fields the API marks as deprecated. This switches them to the current ones.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Refactor

## Changes Made

- Policy simulation uses the current mutation, which takes the same policy body, input and type.
- Blueprint deployment reads the list of created stacks instead of the single-stack field it replaced, so a blueprint that creates more than one stack now prints all of them.
- Affected files: `internal/cmd/policy/simulate.go`, `internal/cmd/blueprint/deploy.go`.

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [x] All existing tests pass

Build, vet and lint are clean, and the existing tests in both packages pass. Both operations were also run against a stub server to confirm the requests match the schema and the responses decode.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings

## Related Issues

N/A
