### PR TITLE
refactor!: read stack hooks from the hooks field

### DIFF
--- a/internal/cmd/stack/list.go
+++ b/internal/cmd/stack/list.go
@@ -207,36 +207,27 @@ type stack struct {
 	Blocker        struct {
 		ID string `graphql:"id" json:"id,omitempty"`
 	} `graphql:"blocker"`
-	AfterApply          []string `graphql:"afterApply" json:"afterApply,omitempty"`
-	BeforeApply         []string `graphql:"beforeApply" json:"beforeApply,omitempty"`
-	AfterInit           []string `graphql:"afterInit" json:"afterInit,omitempty"`
-	BeforeInit          []string `graphql:"beforeInit" json:"beforeInit,omitempty"`
-	AfterPlan           []string `graphql:"afterPlan" json:"afterPlan,omitempty"`
-	BeforePlan          []string `graphql:"beforePlan" json:"beforePlan,omitempty"`
-	AfterPerform        []string `graphql:"afterPerform" json:"afterPerform,omitempty"`
-	BeforePerform       []string `graphql:"beforePerform" json:"beforePerform,omitempty"`
-	AfterDestroy        []string `graphql:"afterDestroy" json:"afterDestroy,omitempty"`
-	BeforeDestroy       []string `graphql:"beforeDestroy" json:"beforeDestroy,omitempty"`
-	Branch              string   `graphql:"branch" json:"branch,omitempty"`
-	CanWrite            bool     `graphql:"canWrite" json:"canWrite,omitempty"`
-	CreatedAt           int64    `graphql:"createdAt" json:"createdAt,omitempty"`
-	Deleted             bool     `graphql:"deleted" json:"deleted,omitempty"`
-	Deleting            bool     `graphql:"deleting" json:"deleting,omitempty"`
-	Description         string   `graphql:"description" json:"description,omitempty"`
-	Labels              []string `graphql:"labels" json:"labels,omitempty"`
-	LocalPreviewEnabled bool     `graphql:"localPreviewEnabled" json:"localPreviewEnabled,omitempty"`
-	LockedBy            string   `graphql:"lockedBy" json:"lockedBy,omitempty"`
-	ManagesStateFile    bool     `graphql:"managesStateFile" json:"managesStateFile,omitempty"`
-	Name                string   `graphql:"name" json:"name,omitempty"`
-	Namespace           string   `graphql:"namespace" json:"namespace,omitempty"`
-	ProjectRoot         string   `graphql:"projectRoot" json:"projectRoot,omitempty"`
-	Provider            string   `graphql:"provider" json:"provider,omitempty"`
-	Repository          string   `graphql:"repository" json:"repository,omitempty"`
-	RunnerImage         string   `graphql:"runnerImage" json:"runnerImage,omitempty"`
-	Starred             bool     `graphql:"starred" json:"starred,omitempty"`
-	State               string   `graphql:"state" json:"state,omitempty"`
-	StateSetAt          int64    `graphql:"stateSetAt" json:"stateSetAt,omitempty"`
-	TerraformVersion    string   `graphql:"terraformVersion" json:"terraformVersion,omitempty"`
+	Hooks               stackHooks `graphql:"hooks" json:"hooks"`
+	Branch              string     `graphql:"branch" json:"branch,omitempty"`
+	CanWrite            bool       `graphql:"canWrite" json:"canWrite,omitempty"`
+	CreatedAt           int64      `graphql:"createdAt" json:"createdAt,omitempty"`
+	Deleted             bool       `graphql:"deleted" json:"deleted,omitempty"`
+	Deleting            bool       `graphql:"deleting" json:"deleting,omitempty"`
+	Description         string     `graphql:"description" json:"description,omitempty"`
+	Labels              []string   `graphql:"labels" json:"labels,omitempty"`
+	LocalPreviewEnabled bool       `graphql:"localPreviewEnabled" json:"localPreviewEnabled,omitempty"`
+	LockedBy            string     `graphql:"lockedBy" json:"lockedBy,omitempty"`
+	ManagesStateFile    bool       `graphql:"managesStateFile" json:"managesStateFile,omitempty"`
+	Name                string     `graphql:"name" json:"name,omitempty"`
+	Namespace           string     `graphql:"namespace" json:"namespace,omitempty"`
+	ProjectRoot         string     `graphql:"projectRoot" json:"projectRoot,omitempty"`
+	Provider            string     `graphql:"provider" json:"provider,omitempty"`
+	Repository          string     `graphql:"repository" json:"repository,omitempty"`
+	RunnerImage         string     `graphql:"runnerImage" json:"runnerImage,omitempty"`
+	Starred             bool       `graphql:"starred" json:"starred,omitempty"`
+	State               string     `graphql:"state" json:"state,omitempty"`
+	StateSetAt          int64      `graphql:"stateSetAt" json:"stateSetAt,omitempty"`
+	TerraformVersion    string     `graphql:"terraformVersion" json:"terraformVersion,omitempty"`
 	SpaceDetails        struct {
 		ID          string  `graphql:"id" json:"id,omitempty"`
 		Name        string  `graphql:"name" json:"name,omitempty"`

--- a/internal/cmd/stack/list_test.go
+++ b/internal/cmd/stack/list_test.go
@@ -1,0 +1,35 @@
+package stack
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestStackJSONHooksAreNested(t *testing.T) {
+	s := stack{ID: "stack-1"}
+	s.Hooks.AfterApply = []string{"echo done"}
+
+	raw, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshalling the stack failed: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshalling the stack failed: %v", err)
+	}
+
+	if _, found := out["afterApply"]; found {
+		t.Error("afterApply should no longer be a top-level key")
+	}
+
+	hooks, ok := out["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("hooks should be an object but was %v", out["hooks"])
+	}
+
+	if got := hooks["afterApply"]; !reflect.DeepEqual(got, []any{"echo done"}) {
+		t.Errorf(`hooks.afterApply should be ["echo done"] but was %v`, got)
+	}
+}

--- a/internal/cmd/stack/show.go
+++ b/internal/cmd/stack/show.go
@@ -25,6 +25,19 @@ const (
 	stackConfigVendorTerragrunt     = "StackConfigVendorTerragrunt"
 )
 
+type stackHooks struct {
+	AfterApply    []string `graphql:"afterApply" json:"afterApply,omitempty"`
+	BeforeApply   []string `graphql:"beforeApply" json:"beforeApply,omitempty"`
+	AfterInit     []string `graphql:"afterInit" json:"afterInit,omitempty"`
+	BeforeInit    []string `graphql:"beforeInit" json:"beforeInit,omitempty"`
+	AfterPlan     []string `graphql:"afterPlan" json:"afterPlan,omitempty"`
+	BeforePlan    []string `graphql:"beforePlan" json:"beforePlan,omitempty"`
+	AfterPerform  []string `graphql:"afterPerform" json:"afterPerform,omitempty"`
+	BeforePerform []string `graphql:"beforePerform" json:"beforePerform,omitempty"`
+	AfterDestroy  []string `graphql:"afterDestroy" json:"afterDestroy,omitempty"`
+	BeforeDestroy []string `graphql:"beforeDestroy" json:"beforeDestroy,omitempty"`
+}
+
 type stackConfigElement struct {
 	ID        string `graphql:"id" json:"id,omitempty"`
 	Checksum  string `graphql:"checksum" json:"checksum,omitempty"`
@@ -190,16 +203,7 @@ type showStackQuery[VC stackVendorConfig] struct {
 		Blocker    struct {
 			ID string `graphql:"id" json:"id,omitempty"`
 		} `graphql:"blocker"`
-		AfterApply          []string             `graphql:"afterApply" json:"afterApply,omitempty"`
-		BeforeApply         []string             `graphql:"beforeApply" json:"beforeApply,omitempty"`
-		AfterInit           []string             `graphql:"afterInit" json:"afterInit,omitempty"`
-		BeforeInit          []string             `graphql:"beforeInit" json:"beforeInit,omitempty"`
-		AfterPlan           []string             `graphql:"afterPlan" json:"afterPlan,omitempty"`
-		BeforePlan          []string             `graphql:"beforePlan" json:"beforePlan,omitempty"`
-		AfterPerform        []string             `graphql:"afterPerform" json:"afterPerform,omitempty"`
-		BeforePerform       []string             `graphql:"beforePerform" json:"beforePerform,omitempty"`
-		AfterDestroy        []string             `graphql:"afterDestroy" json:"afterDestroy,omitempty"`
-		BeforeDestroy       []string             `graphql:"beforeDestroy" json:"beforeDestroy,omitempty"`
+		Hooks               stackHooks           `graphql:"hooks" json:"hooks"`
 		Branch              string               `graphql:"branch" json:"branch,omitempty"`
 		CanWrite            bool                 `graphql:"canWrite" json:"canWrite"`
 		Config              []stackConfigElement `graphql:"config" json:"config,omitempty"`
@@ -368,43 +372,43 @@ func (c *showStackCommand[VC]) outputBehaviorSettings(query showStackQuery[VC]) 
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.BeforeInit, "Before init scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.BeforeInit, "Before init scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.AfterInit, "After init scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.AfterInit, "After init scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.BeforePlan, "Before plan scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.BeforePlan, "Before plan scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.AfterPlan, "After plan scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.AfterPlan, "After plan scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.BeforeApply, "Before apply scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.BeforeApply, "Before apply scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.AfterApply, "After apply scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.AfterApply, "After apply scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.BeforePerform, "Before perform scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.BeforePerform, "Before perform scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.AfterPerform, "After perform scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.AfterPerform, "After perform scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.BeforeDestroy, "Before destroy scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.BeforeDestroy, "Before destroy scripts"); err != nil {
 		return err
 	}
 
-	if err := c.outputScripts(query.Stack.AfterDestroy, "After destroy scripts"); err != nil {
+	if err := c.outputScripts(query.Stack.Hooks.AfterDestroy, "After destroy scripts"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Description

`stack list` and `stack show` read the stack hook scripts from ten fields the API marks as deprecated. This reads them from the current field instead, which nests them, and the JSON output nests with them.

**This is a potential breaking change if someone is parsing this output**
Maybe we are ok with this, maybe not, I'd prefer the repository owner to decide.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Refactor

## Changes Made

- Both commands now request the hook scripts from the field the API points at, rather than the ten deprecated ones.
- Table output is unchanged.
- JSON output changes shape. Before and after, for a stack with one after-apply script:

  ```
  before   {"id":"stack-1","afterApply":["echo done"], ...}
  after    {"id":"stack-1","hooks":{"afterApply":["echo done"]}, ...}
  ```

### Why the output has to move

The GraphQL client builds the request from the Go struct and serialises the same struct to JSON, so nesting one nests the other. Keeping the flat JSON is possible but needs a hand-written marshaller.

## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed
- [x] All existing tests pass

## Screenshots (if applicable)

N/A

## Related Issues

N/A
