### PR TITLE
feat: prompt to re-login when a browser session JWT expires

### DIFF
--- a/browserauth/login.go
+++ b/browserauth/login.go
@@ -1,0 +1,40 @@
+package browserauth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/browser"
+
+	"github.com/spacelift-io/spacectl/client/session"
+)
+
+const loginTimeout = 2 * time.Minute
+
+func Login(ctx context.Context, creds *session.StoredCredentials, host string, port int, noBrowser bool) error {
+	if host == "" {
+		host = "localhost"
+	}
+
+	handler, err := BeginWithBindAddress(ctx, creds, host, port)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Waiting for login responses at %s:%d\n", handler.Host, handler.Port)
+	fmt.Printf("\nOpening browser to %s\n\n", handler.AuthenticationURL)
+
+	if noBrowser {
+		fmt.Printf("Please open the following URL in your browser to complete login:\n%s\n\n", handler.AuthenticationURL)
+	} else if err := browser.OpenURL(handler.AuthenticationURL); err != nil {
+		fmt.Printf("Failed to open the browser: %s\nPlease open the URL manually\n\n", err.Error())
+	}
+
+	fmt.Println("Waiting for login...")
+
+	waitCtx, cancel := context.WithTimeout(ctx, loginTimeout)
+	defer cancel()
+
+	return handler.Wait(waitCtx)
+}

--- a/client/session/api_token.go
+++ b/client/session/api_token.go
@@ -17,14 +17,23 @@ import (
 // a stale one.
 const timePadding = 30 * time.Second
 
+func parseUnverifiedClaims(token string) (jwt.RegisteredClaims, error) {
+	var claims jwt.RegisteredClaims
+
+	_, _, err := (&jwt.Parser{}).ParseUnverified(token, &claims)
+	if err != nil && !errors.Is(err, jwt.ErrTokenUnverifiable) {
+		return claims, fmt.Errorf("could not parse the API token: %w", err)
+	}
+
+	return claims, nil
+}
+
 // FromAPIToken creates a session from a ready API token.
 func FromAPIToken(_ context.Context, client *http.Client) func(string, string) (Session, error) {
 	return func(endpoint, token string) (Session, error) {
-		var claims jwt.RegisteredClaims
-
-		_, _, err := (&jwt.Parser{}).ParseUnverified(token, &claims)
-		if err != nil && !errors.Is(err, jwt.ErrTokenUnverifiable) {
-			return nil, fmt.Errorf("could not parse the API token: %w", err)
+		claims, err := parseUnverifiedClaims(token)
+		if err != nil {
+			return nil, err
 		}
 
 		if len(claims.Audience) != 1 {
@@ -36,11 +45,16 @@ func FromAPIToken(_ context.Context, client *http.Client) func(string, string) (
 			apiEndpoint = endpoint
 		}
 
+		var validUntil time.Time
+		if claims.ExpiresAt != nil {
+			validUntil = claims.ExpiresAt.Time
+		}
+
 		return &apiToken{
 			client:          client,
 			endpoint:        apiEndpoint,
 			jwt:             token,
-			tokenValidUntil: claims.ExpiresAt.Time,
+			tokenValidUntil: validUntil,
 			timer:           time.Now,
 		}, nil
 	}
@@ -74,7 +88,11 @@ func (a *apiToken) isFresh() bool {
 	a.tokenMutex.RLock()
 	defer a.tokenMutex.RUnlock()
 
-	return a.timer().Add(timePadding).Before(a.tokenValidUntil)
+	return !tokenExpired(a.tokenValidUntil, a.timer())
+}
+
+func tokenExpired(validUntil, now time.Time) bool {
+	return !now.Add(timePadding).Before(validUntil)
 }
 
 func (a *apiToken) mutate(ctx context.Context, m any, variables map[string]any) error {

--- a/client/session/from_environment.go
+++ b/client/session/from_environment.go
@@ -122,14 +122,49 @@ func tryAuthMethod(ctx context.Context, client *http.Client, method string, look
 }
 
 func getEndpoint(lookup func(string) (string, bool)) (string, error) {
+	endpoint, deprecated, err := endpointFromEnvironment(lookup)
+	if err != nil {
+		return "", err
+	}
+	if deprecated {
+		fmt.Printf("Environment variable %q is deprecated, please use %q\n", EnvSpaceliftAPIEndpoint, EnvSpaceliftAPIKeyEndpoint)
+	}
+	return endpoint, nil
+}
+
+func endpointFromEnvironment(lookup func(string) (string, bool)) (string, bool, error) {
 	endpoint, ok := lookup(EnvSpaceliftAPIKeyEndpoint)
 	if !ok || endpoint == "" {
 		// Keep backwards compatibility with older version of spacectl.
 		endpoint, ok = lookup(EnvSpaceliftAPIEndpoint)
 		if !ok {
-			return "", errEnvSpaceliftAPIKeyEndpoint
+			return "", false, errEnvSpaceliftAPIKeyEndpoint
 		}
-		fmt.Printf("Environment variable %q is deprecated, please use %q\n", EnvSpaceliftAPIEndpoint, EnvSpaceliftAPIKeyEndpoint)
+		return strings.TrimSuffix(endpoint, "/"), true, nil
 	}
-	return strings.TrimSuffix(endpoint, "/"), nil
+	return strings.TrimSuffix(endpoint, "/"), false, nil
+}
+
+func EnvironmentConfigured() bool {
+	return environmentConfigured(os.LookupEnv)
+}
+
+func environmentConfigured(lookup func(string) (string, bool)) bool {
+	if token, ok := lookup(EnvSpaceliftAPIToken); ok && token != "" {
+		return true
+	}
+
+	endpoint, _, err := endpointFromEnvironment(lookup)
+	if err != nil || endpoint == "" {
+		return false
+	}
+
+	if token, ok := lookup(EnvSpaceliftAPIGitHubToken); ok && token != "" {
+		return true
+	}
+
+	keyID, idOK := lookup(EnvSpaceliftAPIKeyID)
+	keySecret, secretOK := lookup(EnvSpaceliftAPIKeySecret)
+
+	return idOK && keyID != "" && secretOK && keySecret != ""
 }

--- a/client/session/stored_credentials.go
+++ b/client/session/stored_credentials.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // CredentialsType represents the type of credentials being used.
@@ -39,6 +40,25 @@ type StoredCredentials struct {
 	AccessToken string          `json:"access_token,omitempty"`
 	KeyID       string          `json:"key_id,omitempty"`
 	KeySecret   string          `json:"key_secret,omitempty"`
+}
+
+func (s *StoredCredentials) APITokenExpired() bool {
+	if s == nil || s.Type != CredentialsTypeAPIToken {
+		return false
+	}
+	if s.AccessToken == "" {
+		return true
+	}
+
+	claims, err := parseUnverifiedClaims(s.AccessToken)
+	if err != nil {
+		return true
+	}
+	if claims.ExpiresAt == nil {
+		return false
+	}
+
+	return tokenExpired(claims.ExpiresAt.Time, time.Now())
 }
 
 // Session creates a Spacelift Session from stored credentials.

--- a/internal/cmd/authenticated/client.go
+++ b/internal/cmd/authenticated/client.go
@@ -64,6 +64,10 @@ func Ensure(ctx context.Context, _ *cli.Command) (context.Context, error) {
 		return ctx, err
 	}
 
+	if err := maybeReloginExpiredBrowserSession(ctx); err != nil {
+		return ctx, err
+	}
+
 	session, err := session.New(ctx, httpClient)
 	if err != nil {
 		return ctx, err

--- a/internal/cmd/authenticated/relogin.go
+++ b/internal/cmd/authenticated/relogin.go
@@ -1,0 +1,104 @@
+package authenticated
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	"github.com/mattn/go-isatty"
+
+	"github.com/spacelift-io/spacectl/browserauth"
+	"github.com/spacelift-io/spacectl/client/session"
+)
+
+const (
+	envNoAutoLogin = "SPACECTL_NO_AUTO_LOGIN"
+	envBindHost    = "SPACECTL_BIND_HOST"
+	envBindPort    = "SPACECTL_BIND_PORT"
+)
+
+func maybeReloginExpiredBrowserSession(ctx context.Context) error {
+	if !shouldAttemptBrowserRelogin(isInteractive()) {
+		return nil
+	}
+
+	manager, err := session.UserProfileManager()
+	if err != nil {
+		return fmt.Errorf("could not access profile manager: %w", err)
+	}
+
+	profile := manager.Current()
+	if profile == nil || !profile.Credentials.APITokenExpired() {
+		return nil
+	}
+
+	if err := confirmRelogin(); err != nil {
+		return err
+	}
+
+	host, port := bindAddress()
+	if err := browserauth.Login(ctx, profile.Credentials, host, port, false); err != nil {
+		return fmt.Errorf("browser login failed: %w", err)
+	}
+
+	if err := manager.Create(profile); err != nil {
+		return fmt.Errorf("could not persist profile: %w", err)
+	}
+
+	return nil
+}
+
+func shouldAttemptBrowserRelogin(interactive bool) bool {
+	if !interactive || session.EnvironmentConfigured() {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(envNoAutoLogin))) {
+	case "1", "true", "yes":
+		return false
+	default:
+		return true
+	}
+}
+
+func confirmRelogin() error {
+	prompt := promptui.Prompt{
+		Label:     "Session expired. Log in via browser",
+		IsConfirm: true,
+		Default:   "y",
+	}
+
+	_, err := prompt.Run()
+	if err != nil {
+		if errors.Is(err, promptui.ErrAbort) || errors.Is(err, promptui.ErrInterrupt) {
+			return errors.New("login cancelled; run `spacectl profile login` to authenticate")
+		}
+		return fmt.Errorf("could not confirm login: %w", err)
+	}
+
+	return nil
+}
+
+func isInteractive() bool {
+	return isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
+}
+
+func bindAddress() (string, int) {
+	host := os.Getenv(envBindHost)
+	if host == "" {
+		host = "localhost"
+	}
+
+	port := 0
+	if raw := os.Getenv(envBindPort); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil {
+			port = n
+		}
+	}
+
+	return host, port
+}

--- a/internal/cmd/profile/login_command.go
+++ b/internal/cmd/profile/login_command.go
@@ -8,10 +8,8 @@ import (
 	"os"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/manifoldco/promptui"
-	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v3"
 	"golang.org/x/term"
@@ -49,7 +47,7 @@ func loginAction(ctx context.Context, cliCmd *cli.Command) error {
 		storedCredentials.Type = apiTokenProfile.Credentials.Type
 		profileAlias = apiTokenProfile.Alias
 
-		return loginUsingWebBrowser(ctx, cliCmd, &storedCredentials)
+		return loginUsingWebBrowser(ctx, &storedCredentials)
 	}
 
 	reader := bufio.NewReader(os.Stdin)
@@ -76,7 +74,7 @@ func loginAction(ctx context.Context, cliCmd *cli.Command) error {
 			return err
 		}
 	case session.CredentialsTypeAPIToken:
-		return loginUsingWebBrowser(ctx, cliCmd, &storedCredentials)
+		return loginUsingWebBrowser(ctx, &storedCredentials)
 	default:
 		return fmt.Errorf("invalid selection (%s), please try again", storedCredentials.Type)
 	}
@@ -183,35 +181,11 @@ func loginUsingGitHubAccessToken(creds *session.StoredCredentials) error {
 	return nil
 }
 
-func loginUsingWebBrowser(ctx context.Context, _ *cli.Command, creds *session.StoredCredentials) error {
-	// Begin the interactive browser auth flow
-	handler, err := browserauth.BeginWithBindAddress(ctx, creds, bindHost, bindPort)
-	if err != nil {
+func loginUsingWebBrowser(ctx context.Context, creds *session.StoredCredentials) error {
+	if err := browserauth.Login(ctx, creds, bindHost, bindPort, noBrowser); err != nil {
 		return err
 	}
 
-	fmt.Printf("Waiting for login responses at %s:%d\n", handler.Host, handler.Port)
-	fmt.Printf("\nOpening browser to %s\n\n", handler.AuthenticationURL)
-
-	// Attempt to automatically open the URL in the user's browser
-	if noBrowser {
-		fmt.Printf("Please open the following URL in your browser to complete login:\n%s\n\n", handler.AuthenticationURL)
-	} else if err := browser.OpenURL(handler.AuthenticationURL); err != nil {
-		fmt.Printf("Failed to open the browser: %s\nPlease open the URL manually\n\n", err.Error())
-	}
-
-	fmt.Println("Waiting for login...")
-
-	// Create a context that will timeout after 2 minutes while we wait for auth completion
-	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
-
-	// Wait for the timeout or an auth callback
-	if err := handler.Wait(waitCtx); err != nil {
-		return err
-	}
-
-	// Save the shiny new token
 	if err := persistAccessCredentials(creds); err != nil {
 		return err
 	}


### PR DESCRIPTION
Avoid a daily unauthorized failure for interactive profile users by detecting an expired API token and offering the existing browser login flow before the command runs.

Fixes #300

## Description

 
## Testing

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed
- [x] All existing tests pass

 
