### PR TITLE
fix(session): prefer API keys over GitHub tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,23 +239,16 @@ We refer to each method of providing credentials as "credential providers" (like
 The CLI supports the following authentication methods via the environment:
 
 - [Spacelift API tokens](#spacelift-api-tokens).
-- [GitHub tokens](#github-tokens).
 - [Spacelift API keys](#spacelift-api-keys).
+- [GitHub tokens](#github-tokens).
 
-`spacectl` looks for authentication configurations in the order specified above, and will stop as soon as it finds a valid configuration. For example, if a Spacelift API token is specified, GitHub tokens and Spacelift API keys will be ignored, even if their environment variables are specified.
+`spacectl` looks for authentication configurations in the order specified above, and will stop as soon as it finds a valid configuration. For example, if a Spacelift API token is specified, Spacelift API keys and GitHub tokens will be ignored, even if their environment variables are specified.
 
 #### Spacelift API tokens
 
 Spacelift API tokens can be specified using the `SPACELIFT_API_TOKEN` environment variable. When this variable is found, the CLI ignores all the other authentication environment variables because the token contains all the information needed to authenticate.
 
 NOTE: API tokens are generally short-lived and will need to be re-created often.
-
-#### GitHub tokens
-
-GitHub tokens are only available to accounts that use GitHub as their identity provider, but are very convenient for use in GitHub actions. To use a GitHub token, set the following environment variables:
-
-- `SPACELIFT_API_KEY_ENDPOINT` - the URL to your Spacelift account, for example `https://mycorp.app.spacelift.io`.
-- `SPACELIFT_API_GITHUB_TOKEN` - a GitHub personal access token.
 
 #### Spacelift API keys
 
@@ -264,6 +257,13 @@ To use a Spacelift API key, set the following environment variables:
 - `SPACELIFT_API_KEY_ENDPOINT` - the URL to your Spacelift account, for example `https://mycorp.app.spacelift.io`.
 - `SPACELIFT_API_KEY_ID` - the ID of your Spacelift API key. Available via the Spacelift application.
 - `SPACELIFT_API_KEY_SECRET` - the secret for your API key. Only available when the secret is created.
+
+#### GitHub tokens
+
+GitHub tokens are only available to accounts that use GitHub as their identity provider. To use a GitHub token, set the following environment variables:
+
+- `SPACELIFT_API_KEY_ENDPOINT` - the URL to your Spacelift account, for example `https://mycorp.app.spacelift.io`.
+- `SPACELIFT_API_GITHUB_TOKEN` - a GitHub personal access token.
 
 More information about API authentication can be found at <https://docs.spacelift.io/integrations/api#authenticating-with-the-api>.
 

--- a/client/session/from_environment.go
+++ b/client/session/from_environment.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -69,17 +70,20 @@ func FromEnvironment(ctx context.Context, client *http.Client) func(func(string)
 			return tryAuthMethod(ctx, client, preferredMethod, lookup)
 		}
 
-		var lastErr error
-		for _, method := range []string{authMethodToken, authMethodGitHub, authMethodAPIKey} {
+		// All failures are reported: the method the caller meant to use is
+		// indistinguishable from the ones they left unset, so surfacing a
+		// single reason would often be the wrong one.
+		var errs []error
+		for _, method := range []string{authMethodToken, authMethodAPIKey, authMethodGitHub} {
 			session, err := tryAuthMethod(ctx, client, method, lookup)
 			if err != nil {
-				lastErr = err
+				errs = append(errs, err)
 			}
 			if session != nil {
 				return session, nil
 			}
 		}
-		return nil, lastErr
+		return nil, stderrors.Join(errs...)
 	}
 }
 

--- a/client/session/from_environment_test.go
+++ b/client/session/from_environment_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,7 +43,7 @@ func TestFromEnvironment(t *testing.T) {
 			l := lookupWithEnv("", "", "abc123", "SuperSecret")
 			g.It("expect an error to find api endpoint in environment", func() {
 				_, err := FromEnvironment(context.TODO(), nil)(l)
-				g.Assert(err).Equal(errEnvSpaceliftAPIKeyEndpoint)
+				g.Assert(errors.Is(err, errEnvSpaceliftAPIKeyEndpoint)).IsTrue("expected the api endpoint error to be reported")
 			})
 		})
 
@@ -88,7 +89,7 @@ func TestFromEnvironment(t *testing.T) {
 				g.It("expect an error to find api key id in environment", func() {
 					l := lookupWithEnv("https://spacectl.app.spacelift.io", "", "", "SuperSecret")
 					_, err := FromEnvironment(context.TODO(), nil)(l)
-					g.Assert(err).Equal(errEnvSpaceliftAPIKeyID)
+					g.Assert(errors.Is(err, errEnvSpaceliftAPIKeyID)).IsTrue("expected the api key id error to be reported")
 				})
 			})
 
@@ -96,7 +97,7 @@ func TestFromEnvironment(t *testing.T) {
 				g.It("expect an error to find api key secret in environment", func() {
 					l := lookupWithEnv("https://spacectl.app.spacelift.io", "", "abc123", "")
 					_, err := FromEnvironment(context.TODO(), nil)(l)
-					g.Assert(err).Equal(errEnvSpaceliftAPIKeySecret)
+					g.Assert(errors.Is(err, errEnvSpaceliftAPIKeySecret)).IsTrue("expected the api key secret error to be reported")
 				})
 			})
 		})


### PR DESCRIPTION
## Description

GitHub personal access tokens are being retired as an authentication method (a PAT belongs to no OAuth application, so Spacelift cannot verify it was issued for Spacelift). Backend side: spacelift-io/backend#17064.

Env auth order changes from `token → github → apikey` to `token → apikey → github`.

Today a caller who adds API key variables to migrate only lands on them by accident: the PAT is tried first, fails, and the loop falls through on error (`from_environment.go:75-77`). Every invocation burns a failed exchange. After this, adding an API key just works.

This changes documented precedence for anyone setting both, so it is a behaviour change rather than a silent fix. `SPACELIFT_API_PREFERRED_METHOD` is unaffected, it bypasses the ordering entirely.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):